### PR TITLE
Add a top level .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# IDE Settings
+.idea/
+.project
+.pydevproject
+.vscode/
+
+# Distribution / Packaging
+*.egg*
+*.whl
+__pycache__/
+site/
+build/
+
+# Reporting
+.coverage
+
+# Environmnents
+venv/
+venv*/
+.venv/
+.env
+.tox/
+
+.DS_store

--- a/uv.lock
+++ b/uv.lock
@@ -344,19 +344,15 @@ dev = [
     { name = "bumpver" },
     { name = "coverage", extra = ["toml"] },
     { name = "evo-objects", extra = ["aiohttp", "utils"] },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "parameterized" },
-    { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
 ]
 test = [
     { name = "evo-objects", extra = ["aiohttp", "utils"] },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "parameterized" },
-    { name = "pyarrow" },
     { name = "pytest" },
 ]
 
@@ -373,19 +369,15 @@ dev = [
     { name = "bumpver" },
     { name = "coverage", extras = ["toml"] },
     { name = "evo-objects", extras = ["aiohttp", "utils"], editable = "packages/evo-objects" },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "parameterized", specifier = "==0.9.0" },
-    { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
 ]
 test = [
     { name = "evo-objects", extras = ["aiohttp", "utils"], editable = "packages/evo-objects" },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "parameterized", specifier = "==0.9.0" },
-    { name = "pyarrow" },
     { name = "pytest" },
 ]
 


### PR DESCRIPTION
I ran the tests in another PR and got spammed with pycache folders.
Adding this back in at the top level as called out in https://github.com/seequent/evo-python-sdk/pull/8.

Also ran `uv sync` which appears to have removed some unneeded packages.
