### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -22,6 +22,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequent/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequent/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

Resolves #10

Fixes an error when running in Python 3.13:

```python
>       if response_type is not None and issubclass(response_type, HTTPResponse):
E       TypeError: issubclass() arg 1 must be a class

packages/evo-client-common/src/evo/common/connector.py:379: TypeError
```

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
