### PR TITLE
Missed a package when re-numbering

### DIFF
--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-objects"
-version = "2.2.2"
+version = "0.1.0"
 requires-python = ">=3.10"
 readme = { file = "README.md", content-type = "text/markdown" }
 dependencies = [


### PR DESCRIPTION
I missed a package in https://github.com/seequent/evo-python-sdk/pull/17

Checked Artifactory, and it was the only one missing 😅 
![image](https://github.com/user-attachments/assets/8d64d693-9d83-4c56-b175-485abddbf836)

