### PR TITLE
Add release workflows for each package

### DIFF
--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -16,13 +16,11 @@ runs:
       shell: bash
       run: uv build --package ${{ inputs.package }}
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: ./dist
-        name: ${{ inputs.package }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
-    - name: Publish package
-      shell: bash
-      run: |
-        echo "Coming soon..." 
+    - name: Upload artifacts to GitHub Release
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
+      with:
+        files: |
+          dist

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+    labels:
+      - ignore-for-release
+  categories:
+    - title: evo-client-common
+      labels:
+        - evo-client-common
+    - title: evo-files
+      labels:
+        - evo-files
+    - title: evo-objects
+      labels:
+        - evo-objects
+    - title: Breaking Changes 🛠
+      labels:
+        - semver-major
+        - breaking-change
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/compile-changelog.yaml
+++ b/.github/workflows/compile-changelog.yaml
@@ -1,0 +1,49 @@
+name: Compile changelog
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  compile-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Add release notes to top of changelog
+        run: |
+          echo "# Changelog" >> new_entry
+          echo "## ${{ github.event.release.tag_name }}" >> new_entry
+          echo "${{ github.event.release.body }}" >> new_entry
+          echo "" >> new_entry
+          sed -i '/^# Changelog/d' CHANGELOG.md
+          cat new_entry CHANGELOG.md > combined_entry && mv combined_entry CHANGELOG.md
+
+      - name: Adjust heading levels and casing
+        shell: bash
+        run: |
+          sed -i "s/^## What's Changed/### What's changed/g" CHANGELOG.md
+          sed -i 's/^### Breaking Changes/#### Breaking changes/g' CHANGELOG.md
+          sed -i 's/^### Other Changes/#### Other changes/g' CHANGELOG.md
+          sed -i 's/^## New Contributors/### New contributors/g' CHANGELOG.md
+          sed -i 's/\*\*Full Changelog\*\*:/\*\*Full changelog\*\*:/g' CHANGELOG.md
+
+      - name: Remove all comments
+        shell: bash
+        run: |
+          sed -i '/^<!--/d' CHANGELOG.md
+
+      - name: Commit changes
+        uses: iarekylew00t/verified-bot-commit@f6a8ea6511aea763df25b7c7e3788349f3d222c2
+        with:
+          message: "Add ${{ github.event.release.tag_name }} to changelog"
+          files: |
+            CHANGELOG.md
+
+      - name: Push changes
+        run: git push origin main

--- a/.github/workflows/publish-evo-client-common.yaml
+++ b/.github/workflows/publish-evo-client-common.yaml
@@ -1,24 +1,26 @@
 name: Build and publish evo-client-common
 
 permissions:
-  contents: read
+  # Required for publishing release artifacts
+  contents: write
+  # Required for PyPI trusted publishing
+  id-token: write
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - packages/evo-client-common/**
+  release:
+    types: [released]
 
 jobs:
   run-tests:
+    if: startsWith(github.event.release.tag_name, 'evo-client-common@')
     uses: ./.github/workflows/run-all-tests.yaml
 
-  build-package:
+  build-and-publish:
     name: Build and publish package
-    needs: [run-tests]
+    needs: run-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-client-common

--- a/.github/workflows/publish-evo-files.yaml
+++ b/.github/workflows/publish-evo-files.yaml
@@ -1,24 +1,26 @@
 name: Build and publish evo-files
 
 permissions:
-  contents: read
+  # Required for publishing release artifacts
+  contents: write
+  # Required for PyPI trusted publishing
+  id-token: write
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - packages/evo-files/**
+  release:
+    types: [released]
 
 jobs:
   run-tests:
+    if: startsWith(github.event.release.tag_name, 'evo-files@')
     uses: ./.github/workflows/run-all-tests.yaml
 
-  build-package:
+  build-and-publish:
     name: Build and publish package
-    needs: [run-tests]
+    needs: run-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-files

--- a/.github/workflows/publish-evo-objects.yaml
+++ b/.github/workflows/publish-evo-objects.yaml
@@ -1,24 +1,26 @@
 name: Build and publish evo-objects
 
 permissions:
-  contents: read
+  # Required for publishing release artifacts
+  contents: write
+  # Required for PyPI trusted publishing
+  id-token: write
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - packages/evo-objects/**
+  release:
+    types: [released]
 
 jobs:
   run-tests:
+    if: startsWith(github.event.release.tag_name, 'evo-objects@')
     uses: ./.github/workflows/run-all-tests.yaml
 
-  build-package:
+  build-and-publish:
     name: Build and publish package
-    needs: [run-tests]
+    needs: run-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-objects

--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   run-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,1 @@
 # Changelog
-
-## Version x.x.x
-
-#### Breaking Changes 📣
-
-- Breaking change description
- 
-#### Fixes 🔧
-
-- Fix description
-
-#### Additions 🎉
- 
-- Addition description

--- a/packages/evo-client-common/src/evo/oauth/data.py
+++ b/packages/evo-client-common/src/evo/oauth/data.py
@@ -17,12 +17,12 @@ from base64 import urlsafe_b64decode
 from datetime import datetime, timedelta, timezone
 from enum import Flag, auto
 from typing import Literal, Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from evo.common.utils import BackoffLinear, Retry
 from evo.oauth.exceptions import OAuthError, OIDCError
-from urllib.parse import urlparse
 
 __all__ = [
     "AccessToken",


### PR DESCRIPTION
These workflows assume that tags will be formed as `evo-files@v1.2.3`, will skip if they are not prefixed with each package, and then will publish to PyPI and upload artifacts to the GitHub release.

Individual workflow files are required for PyPI trusted publishing, since we are using a monorepo serving multiple projects.

The changelog release configuration (`.github/release.yml`) defines which labels will be used for aggregating changes into categories, when you click "generate release notes" during a new release creation. Since this is a monorepo, we've decided to group by package rather than by feature/bug/change type.

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
