### PR TITLE
Use gh CLI to publish release artifacts to GitHub

### DIFF
--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -2,6 +2,9 @@ name: "Publish"
 description: "Builds and publishes a package"
 
 inputs:
+  TAG:
+    required: true
+    description: "GitHub release name/tag to upload artifacts to"
   PACKAGE:
     required: true
     description: "uv package to publish"
@@ -19,8 +22,6 @@ runs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-    - name: Upload artifacts to GitHub Release
-      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
-      with:
-        files: |
-          dist
+    - name: Upload artifact to GitHub Release
+      shell: bash
+      run: gh release upload ${{ inputs.tag }} dist/*

--- a/.github/workflows/publish-evo-files.yaml
+++ b/.github/workflows/publish-evo-files.yaml
@@ -10,6 +10,9 @@ on:
   release:
     types: [released]
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-files@')
@@ -24,3 +27,4 @@ jobs:
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-files
+          TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-evo-objects.yaml
+++ b/.github/workflows/publish-evo-objects.yaml
@@ -10,6 +10,9 @@ on:
   release:
     types: [released]
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-objects@')
@@ -24,3 +27,4 @@ jobs:
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-objects
+          TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-evo-sdk-common.yaml
+++ b/.github/workflows/publish-evo-sdk-common.yaml
@@ -10,6 +10,9 @@ on:
   release:
     types: [released]
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   run-tests:
     if: startsWith(github.event.release.tag_name, 'evo-sdk-common@')
@@ -24,3 +27,4 @@ jobs:
       - uses: ./.github/actions/publish
         with:
           PACKAGE: evo-sdk-common
+          TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

Removes a third-party GH action in favour of using the native GH CLI

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
