### PR TITLE
Add AccessTokenAuthorizer to authorize requests with the provided token

### DIFF
--- a/packages/evo-sdk-common/docs/oauth.md
+++ b/packages/evo-sdk-common/docs/oauth.md
@@ -111,3 +111,16 @@ authorizer = ClientCredentialsAuthorizer(
 
 print(await authorizer.get_default_headers())
 ```
+
+## Specifying a token with AccessTokenAuthorizer
+
+If you already have an access token, and you're happy to manage the validity of it and refresh it yourself, you can
+use the `AccessTokenAuthorizer` to skip all OAuth processes and simply use the token to authorise requests.
+
+```python
+from evo.oauth import AccessTokenAuthorizer
+
+authorizer = AccessTokenAuthorizer(access_token="your-access-token-here")
+
+print(authorizer.get_default_headers())
+```

--- a/packages/evo-sdk-common/docs/quickstart.md
+++ b/packages/evo-sdk-common/docs/quickstart.md
@@ -115,7 +115,10 @@ authorizer = AuthorizationCodeAuthorizer(
 await authorizer.login()
 ```
 
-Alternatively, a client of `client credientials` grant type can use the `ClientCredentialsAuthorizer` for authorization into Evo. This allows for service to service requests, instead of user login and redirects. 
+If you already have an access token, and don't need to worry about whether it's expired or not, you can use the
+`evo.oauth.AccessTokenAuthorizer` class.
+
+Alternatively, a client of `client credentials` grant type can use the `ClientCredentialsAuthorizer` for authorization into Evo. This allows for service to service requests, instead of user login and redirects.
 
 ``` python
 from evo.oauth import OIDCConnector, ClientCredentialsAuthorizer, OAuthScopes

--- a/packages/evo-sdk-common/src/evo/oauth/__init__.py
+++ b/packages/evo-sdk-common/src/evo/oauth/__init__.py
@@ -11,7 +11,12 @@
 
 from __future__ import annotations
 
-from .authorizer import AuthorizationCodeAuthorizer, ClientCredentialsAuthorizer, DeviceFlowAuthorizer
+from .authorizer import (
+    AccessTokenAuthorizer,
+    AuthorizationCodeAuthorizer,
+    ClientCredentialsAuthorizer,
+    DeviceFlowAuthorizer,
+)
 from .data import AccessToken, DeviceFlowResponse, OAuthScopes, UserAccessToken
 from .exceptions import OAuthError, OIDCError
 from .oauth_redirect_handler import OAuthRedirectHandler
@@ -19,6 +24,7 @@ from .oidc import OIDCConnector
 
 __all__ = [
     "AccessToken",
+    "AccessTokenAuthorizer",
     "AuthorizationCodeAuthorizer",
     "ClientCredentialsAuthorizer",
     "DeviceFlowAuthorizer",

--- a/packages/evo-sdk-common/src/evo/oauth/authorizer.py
+++ b/packages/evo-sdk-common/src/evo/oauth/authorizer.py
@@ -372,9 +372,9 @@ class AccessTokenAuthorizer(IAuthorizer):
         """
         self._access_token = access_token
 
-    def refresh_token(self) -> bool:
+    async def refresh_token(self) -> bool:
         logger.debug("AccessTokenAuthorizer does not support refreshing expired tokens.")
         return False
 
-    def get_default_headers(self) -> HTTPHeaderDict:
+    async def get_default_headers(self) -> HTTPHeaderDict:
         return HTTPHeaderDict({"Authorization": f"Bearer {self._access_token}"})

--- a/packages/evo-sdk-common/src/evo/oauth/authorizer.py
+++ b/packages/evo-sdk-common/src/evo/oauth/authorizer.py
@@ -25,6 +25,7 @@ from .oauth_redirect_handler import OAuthRedirectHandler
 from .oidc import OIDCConnector
 
 __all__ = [
+    "AccessTokenAuthorizer",
     "AuthorizationCodeAuthorizer",
     "ClientCredentialsAuthorizer",
     "DeviceFlowAuthorizer",
@@ -360,3 +361,20 @@ class DeviceFlowAuthorizer(_BaseAuthorizer[AccessToken]):
             and "urn:ietf:params:oauth:grant-type:device_code" not in self._connector.config.grant_types_supported
         ):
             raise OIDCError("Authorization provider does not support the 'device_code' grant type.")
+
+
+class AccessTokenAuthorizer(IAuthorizer):
+    def __init__(self, access_token: str):
+        """An OAuth authorizer that uses the provided access token to authorize requests.
+
+        This authorizer does not make any attempt to refresh expired tokens. This is handy if you already have an
+        access token and are happy to support refreshing it when it expires outside of this interface.
+        """
+        self._access_token = access_token
+
+    def refresh_token(self) -> bool:
+        logger.debug("AccessTokenAuthorizer does not support refreshing expired tokens.")
+        return False
+
+    def get_default_headers(self) -> HTTPHeaderDict:
+        return HTTPHeaderDict({"Authorization": f"Bearer {self._access_token}"})

--- a/packages/evo-sdk-common/tests/oauth/test_access_token_authorizer.py
+++ b/packages/evo-sdk-common/tests/oauth/test_access_token_authorizer.py
@@ -1,0 +1,12 @@
+from evo.oauth.authorizer import AccessTokenAuthorizer
+
+
+class TestAccessTokenAuthorizer:
+    def test_get_default_headers(self) -> None:
+        authorizer = AccessTokenAuthorizer(access_token="abc-123")
+        headers = authorizer.get_default_headers()
+        assert headers == {"Authorization": "Bearer abc-123"}
+
+    def test_refresh_token(self) -> None:
+        authorizer = AccessTokenAuthorizer(access_token="abc-123")
+        assert not authorizer.refresh_token()

--- a/packages/evo-sdk-common/tests/oauth/test_access_token_authorizer.py
+++ b/packages/evo-sdk-common/tests/oauth/test_access_token_authorizer.py
@@ -1,12 +1,15 @@
+import unittest
+
 from evo.oauth.authorizer import AccessTokenAuthorizer
 
 
-class TestAccessTokenAuthorizer:
-    def test_get_default_headers(self) -> None:
-        authorizer = AccessTokenAuthorizer(access_token="abc-123")
-        headers = authorizer.get_default_headers()
+class TestAccessTokenAuthorizer(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.authorizer = AccessTokenAuthorizer(access_token="abc-123")
+
+    async def test_get_default_headers(self) -> None:
+        headers = await self.authorizer.get_default_headers()
         assert headers == {"Authorization": "Bearer abc-123"}
 
-    def test_refresh_token(self) -> None:
-        authorizer = AccessTokenAuthorizer(access_token="abc-123")
-        assert not authorizer.refresh_token()
+    async def test_refresh_token(self) -> None:
+        assert not await self.authorizer.refresh_token()


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

If you already have a token and you simply need to authoriser requests with it, this authorizer skips OAuth processes that other `IAuthorizer` implementations use and adds the access token to the authentication header for the request.

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
