### PR TITLE
Add Makefile with shortcuts for linting and testing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,6 @@
 [*]
 insert_final_newline = true
+indent_style = space
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+lint:
+	uv run --only-dev ruff check
+	uv run --only-dev ruff format --check
+
+lint-fix:
+	uv run --only-dev ruff format
+
+test-common:
+	uv run --package evo-sdk-common pytest packages/evo-sdk-common/tests
+
+test-files:
+	uv run --package evo-files pytest packages/evo-files/tests
+
+test-objects:
+	uv run --package evo-objects pytest packages/evo-objects/tests
+
+test:
+	@make test-common
+	@make test-files
+	@make test-objects

--- a/uv.lock
+++ b/uv.lock
@@ -780,7 +780,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

E.g. `make lint` instead of looking up the command in GH Actions each time

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
