### PR TITLE
Reference the notebooks optional dep to the readme

### DIFF
--- a/packages/evo-sdk-common/README.md
+++ b/packages/evo-sdk-common/README.md
@@ -16,8 +16,14 @@ with Seequent Evo APIs.
 
 ## Installation
 
+To install only the essential SDK components:
 ```
 pip install evo-sdk-common
+```
+
+To use the SDK within a Jupyter notebook, include the `notebooks` optional dependency:
+```
+pip install evo-sdk-common[notebooks]
 ```
 
 ## Usage

--- a/packages/evo-sdk-common/README.md
+++ b/packages/evo-sdk-common/README.md
@@ -16,7 +16,6 @@ with Seequent Evo APIs.
 
 ## Installation
 
-To install only the essential SDK components:
 ```
 pip install evo-sdk-common
 ```


### PR DESCRIPTION
## Description

Highlighting the `notebooks` dependency in the `evo-sdk-common` README will provide a smoother experience for new developers.

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
