### PR TITLE
Adding list workspaces summary to the evo python sdk.

### DIFF
--- a/packages/evo-sdk-common/src/evo/workspaces/__init__.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/__init__.py
@@ -10,16 +10,31 @@
 #  limitations under the License.
 
 from .client import WorkspaceAPIClient
-from .data import BoundingBox, Coordinate, ServiceUser, User, UserPermission, UserRole, Workspace, WorkspaceRole
+from .data import (
+    BasicWorkspace,
+    BoundingBox,
+    Coordinate,
+    OrderByOperatorEnum,
+    ServiceUser,
+    User,
+    UserPermission,
+    UserRole,
+    Workspace,
+    WorkspaceOrderByEnum,
+    WorkspaceRole,
+)
 
 __all__ = [
+    "BasicWorkspace",
     "BoundingBox",
     "Coordinate",
+    "OrderByOperatorEnum",
     "ServiceUser",
     "User",
     "UserPermission",
     "UserRole",
     "Workspace",
     "WorkspaceAPIClient",
+    "WorkspaceOrderByEnum",
     "WorkspaceRole",
 ]

--- a/packages/evo-sdk-common/src/evo/workspaces/data.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/data.py
@@ -22,10 +22,13 @@ from evo.common import Environment, ServiceUser
 from .exceptions import UserPermissionTypeError
 
 __all__ = [
+    "BasicWorkspace",
     "BoundingBox",
     "Coordinate",
     "OrderByOperatorEnum",
+    "User",
     "UserPermission",
+    "UserRole",
     "Workspace",
     "WorkspaceOrderByEnum",
     "WorkspaceRole",
@@ -113,14 +116,17 @@ class BoundingBox:
 
 
 @dataclass(frozen=True, kw_only=True)
-class Workspace:
-    """Metadata about a workspace environment."""
-
+class BasicWorkspace:
     id: UUID
     """The workspace UUID."""
 
     display_name: str
     """The workspace display name."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class Workspace(BasicWorkspace):
+    """Metadata about a workspace environment."""
 
     description: str | None
     """The workspace description."""

--- a/packages/evo-sdk-common/src/evo/workspaces/endpoints/api/workspaces_api.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/endpoints/api/workspaces_api.py
@@ -730,6 +730,125 @@ class WorkspacesApi:
             request_timeout=request_timeout,
         )
 
+    async def list_workspaces_summary(
+        self,
+        org_id: str,
+        limit: int | None = None,
+        offset: int | None = None,
+        sort: str | None = None,
+        order_by: str | None = None,
+        filter_created_by: str | None = None,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+        filter_name: str | None = None,
+        name: str | None = None,
+        deleted: bool | None = None,
+        filter_user_id: str | None = None,
+        additional_headers: dict[str, str] | None = None,
+        request_timeout: int | float | tuple[int | float, int | float] | None = None,
+    ) -> ListWorkspaceSummaryResponse:  # noqa: F405
+        """List Workspaces Summary
+
+
+        :param org_id:
+            Format: `uuid`
+            Example: `'org_id_example'`
+        :param limit: (optional) The maximum number of results to return.
+            Example: `56`
+        :param offset: (optional) The (zero-based) offset of the first item returned in the collection.
+            Example: `0`
+        :param sort: (optional) An optional comma separated list of fields to sort the results by. Options are: `name`, `-name`, `created_at`, `-created_at`, `updated_at`, `-updated_at`, `user_role`, `-user_role`.
+            Example: `'sort_example'`
+        :param order_by: (optional) An optional, comma-separated list of fields by which to order the results. Each field could be prefixed with an order operator: `asc:` for ascending order or `desc:` for descending order, default is ascending order. The sortable fields are: `name`, `created_at`, `updated_at`, and `user_role`. You can also do compound sorts by comma separating your order params, e.g. `asc:user_role,desc:name`. This will sort by user_role in ascending order and then by name in descending order as a secondary sort.
+            Example: `'order_by_example'`
+        :param filter_created_by: (optional) Filter by workspace that a user has created, by user ID.
+            Format: `uuid`
+            Example: `'filter_created_by_example'`
+        :param created_at: (optional) Filter by the time workspace has created.
+            Example: `'created_at_example'`
+        :param updated_at: (optional) Filter by the latest time workspace was updated.
+            Example: `'updated_at_example'`
+        :param filter_name: (optional) Filter by workspace name.
+            Example: `'filter_name_example'`
+        :param name: (optional) Filter by workspace name.
+            Example: `'name_example'`
+        :param deleted: (optional) Include workspaces that have been deleted.
+            Example: `True`
+        :param filter_user_id: (optional) Filter by workspaces that a user ID has access to.
+            Format: `uuid`
+            Example: `'filter_user_id_example'`
+        :param additional_headers: (optional) Additional headers to send with the request.
+        :param request_timeout: (optional) Timeout setting for this request. If one number is provided, it will be the
+            total request timeout. It can also be a pair (tuple) of (connection, read) timeouts.
+
+        :return: Returns the result object.
+
+        :raise evo.common.exceptions.BadRequestException: If the server responds with HTTP status 400.
+        :raise evo.common.exceptions.UnauthorizedException: If the server responds with HTTP status 401.
+        :raise evo.common.exceptions.ForbiddenException: If the server responds with HTTP status 403.
+        :raise evo.common.exceptions.NotFoundException: If the server responds with HTTP status 404.
+        :raise evo.common.exceptions.BaseTypedError: If the server responds with any other HTTP status between
+            400 and 599, and the body of the response contains a descriptive `type` parameter.
+        :raise evo.common.exceptions.EvoAPIException: If the server responds with any other HTTP status between 400
+            and 599, and the body of the response does not contain a `type` parameter.
+        :raise evo.common.exceptions.UnknownResponseError: For other HTTP status codes with no corresponding response
+            type in `response_types_map`.
+        """
+        # Prepare the path parameters.
+        _path_params = {
+            "org_id": org_id,
+        }
+
+        # Prepare the query parameters.
+        _query_params = {}
+        if limit is not None:
+            _query_params["limit"] = limit
+        if offset is not None:
+            _query_params["offset"] = offset
+        if sort is not None:
+            _query_params["sort"] = sort
+        if order_by is not None:
+            _query_params["order_by"] = order_by
+        if filter_created_by is not None:
+            _query_params["filter[created_by]"] = filter_created_by
+        if created_at is not None:
+            _query_params["created_at"] = created_at
+        if updated_at is not None:
+            _query_params["updated_at"] = updated_at
+        if filter_name is not None:
+            _query_params["filter[name]"] = filter_name
+        if name is not None:
+            _query_params["name"] = name
+        if deleted is not None:
+            _query_params["deleted"] = deleted
+        if filter_user_id is not None:
+            _query_params["filter[user_id]"] = filter_user_id
+
+        # Prepare the header parameters.
+        _header_params = {
+            "Accept": "application/json",
+        }
+        if additional_headers is not None:
+            _header_params.update(additional_headers)
+
+        # Define the collection formats.
+        _collection_formats = {}
+
+        _response_types_map = {
+            "200": ListWorkspaceSummaryResponse,  # noqa: F405
+        }
+
+        return await self.connector.call_api(
+            method=RequestMethod.GET,
+            resource_path="/workspace/orgs/{org_id}/workspaces/summary",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            collection_formats=_collection_formats,
+            response_types_map=_response_types_map,
+            request_timeout=request_timeout,
+        )
+
     async def restore_soft_deleted_workspace(
         self,
         workspace_id: str,

--- a/packages/evo-sdk-common/src/evo/workspaces/endpoints/models.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/endpoints/models.py
@@ -38,6 +38,14 @@ class BaseInstanceUserRoleResponse(CustomBaseModel):
     name: Annotated[StrictStr, Field(title="Name")]
 
 
+class BasicWorkspaceResponse(CustomBaseModel):
+    id: Annotated[UUID, Field(title="Id")]
+    name: Annotated[StrictStr, Field(title="Name")]
+    """
+    The name of the workspace, unique within an organization and hub
+    """
+
+
 class Coordinate(RootModel[list[StrictFloat | StrictInt]]):
     root: Annotated[list[StrictFloat | StrictInt], Field(max_length=2, min_length=2)]
     """
@@ -195,6 +203,11 @@ class ListInstanceUsersResponse(CustomBaseModel):
 class ListUserRoleResponse(CustomBaseModel):
     links: Annotated[dict[str, Any], Field(title="Links")]
     results: Annotated[list[User], Field(title="Results")]
+
+
+class ListWorkspaceSummaryResponse(CustomBaseModel):
+    links: PaginationLinks
+    results: Annotated[list[BasicWorkspaceResponse], Field(title="Results")]
 
 
 class MlEnablementRequest(CustomBaseModel):

--- a/packages/evo-sdk-common/tests/common/utils/test_health_check.py
+++ b/packages/evo-sdk-common/tests/common/utils/test_health_check.py
@@ -14,11 +14,12 @@ from typing import Any
 
 from parameterized import parameterized
 
-from data import load_test_data
 from evo.common import DependencyStatus, HealthCheckType, RequestMethod, ServiceHealth, ServiceStatus
 from evo.common.exceptions import ServiceHealthCheckFailed
 from evo.common.test_tools import TestWithConnector
 from evo.common.utils import get_service_health, get_service_status
+
+from ...data import load_test_data
 
 
 def using_test_data(full: bool, with_dependencies: bool, strict: bool) -> Any:

--- a/packages/evo-sdk-common/tests/data/list_workspaces_summary.json
+++ b/packages/evo-sdk-common/tests/data/list_workspaces_summary.json
@@ -1,0 +1,24 @@
+{
+    "links": {
+        "first": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary",
+        "next": null,
+        "previous": null,
+        "count": 3,
+        "last": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary",
+        "total": 3
+    },
+    "results": [
+        {
+            "id": "00000000-0000-0000-0000-00000000000a",
+            "name": "Test Workspace A"
+        },
+        {
+            "id": "00000000-0000-0000-0000-00000000000b",
+            "name": "Test Workspace B"
+        },
+        {
+            "id": "00000000-0000-0000-0000-00000000000c",
+            "name": "Test Workspace C"
+        }
+    ]
+}

--- a/packages/evo-sdk-common/tests/data/list_workspaces_summary_paginated_0.json
+++ b/packages/evo-sdk-common/tests/data/list_workspaces_summary_paginated_0.json
@@ -1,0 +1,20 @@
+{
+    "links": {
+        "first": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=0",
+        "next": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=2",
+        "previous": null,
+        "count": 2,
+        "last": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=2",
+        "total": 3
+    },
+    "results": [
+        {
+            "id": "00000000-0000-0000-0000-00000000000a",
+            "name": "Test Workspace A"
+        },
+        {
+            "id": "00000000-0000-0000-0000-00000000000b",
+            "name": "Test Workspace B"
+        }
+    ]
+}

--- a/packages/evo-sdk-common/tests/data/list_workspaces_summary_paginated_1.json
+++ b/packages/evo-sdk-common/tests/data/list_workspaces_summary_paginated_1.json
@@ -1,0 +1,16 @@
+{
+    "links": {
+        "first": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=0",
+        "next": null,
+        "previous": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=0",
+        "count": 1,
+        "last": "http://unittest.localhost/workspace/orgs/00000000-0000-0000-0000-000000000000/workspaces/summary?limit=2&offset=2",
+        "total": 3
+    },
+    "results": [
+        {
+            "id": "00000000-0000-0000-0000-00000000000c",
+            "name": "Test Workspace C"
+        }
+    ]
+}

--- a/packages/evo-sdk-common/tests/discovery/test_discovery_client.py
+++ b/packages/evo-sdk-common/tests/discovery/test_discovery_client.py
@@ -14,10 +14,11 @@ from uuid import UUID
 
 from parameterized import param, parameterized
 
-from data import load_test_data
 from evo.common.data import RequestMethod
 from evo.common.test_tools import MockResponse, TestWithConnector
 from evo.discovery import DiscoveryAPIClient, Hub, Organization
+
+from ..data import load_test_data
 
 
 def _sample_data_as_response_content(sample_data: dict) -> str:


### PR DESCRIPTION
## Description
Adding `list_workspaces_summary` method to `WorkspaceAPIClient`. This endpoint allows for optionally paginated calls for workspaces. Returning only id and name. To be used when list performance is important.

Supports all query parameters used in the standard `list_workspaces` method.

## Checklist

- [x] I have read the contributing guide and the code of conduct
