### PR TITLE
Update default redirect URL for OAuth in notebooks so it does not refer to OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## evo-sdk-common@v0.4.1
+### What's changed
+#### evo-sdk-common
+* Update default redirect URL for OAuth in notebooks so it does not refer to OIDC by @robbieaverill in https://github.com/SeequentEvo/evo-python-sdk/pull/84
+
+**Full changelog**: https://github.com/SeequentEvo/evo-python-sdk/compare/evo-sdk-common@v0.4.0...evo-sdk-common@v0.4.1
+
 ## evo-sdk-common@v0.4.0
 ### What's changed
 #### evo-sdk-common
@@ -9,7 +16,7 @@
 * @Gibson-Seequent made their first contribution in https://github.com/SeequentEvo/evo-python-sdk/pull/80
 * @lokkochan made their first contribution in https://github.com/SeequentEvo/evo-python-sdk/pull/82
 
-**Full Changelog**: https://github.com/SeequentEvo/evo-python-sdk/compare/evo-sdk-common@v0.3.0...evo-sdk-common@v0.4.0
+**Full changelog**: https://github.com/SeequentEvo/evo-python-sdk/compare/evo-sdk-common@v0.3.0...evo-sdk-common@v0.4.0
 
 ## evo-sdk@v0.1.2
 ### What's changed

--- a/packages/evo-sdk-common/docs/examples/notebook-utilities.ipynb
+++ b/packages/evo-sdk-common/docs/examples/notebook-utilities.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "manager = await ServiceManagerWidget.with_auth_code(\n",
     "    client_id=\"your-client-id\",\n",
-    "    redirect_url=\"http://localhost:3000/signin-oidc\",\n",
+    "    redirect_url=\"http://localhost:3000/signin-callback\",\n",
     "    cache_location=\"./notebook-data/with-auth-code\",\n",
     ").login()"
    ]

--- a/packages/evo-sdk-common/docs/examples/oauth.ipynb
+++ b/packages/evo-sdk-common/docs/examples/oauth.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "# OAuth client app credentials\n",
     "# See: https://developer.seequent.com/docs/guides/getting-started/apps-and-tokens\n",
-    "REDIRECT_URL = \"http://localhost:3000/signin-oidc\"\n",
+    "REDIRECT_URL = \"http://localhost:3000/signin-callback\"\n",
     "CLIENT_NAME = \"Your Client Name\"\n",
     "CLIENT_ID = \"your-client-id\"\n",
     "\n",

--- a/packages/evo-sdk-common/docs/examples/quickstart.ipynb
+++ b/packages/evo-sdk-common/docs/examples/quickstart.ipynb
@@ -78,7 +78,7 @@
     "# OAuth client app credentials\n",
     "# See: https://developer.seequent.com/docs/guides/getting-started/apps-and-tokens\n",
     "CLIENT_ID = \"your-client-id\"\n",
-    "REDIRECT_URL = \"http://localhost:3000/signin-oidc\"\n",
+    "REDIRECT_URL = \"http://localhost:3000/signin-callback\"\n",
     "\n",
     "authorizer = AuthorizationCodeAuthorizer(\n",
     "    redirect_url=REDIRECT_URL,\n",

--- a/packages/evo-sdk-common/docs/examples/workspace-client.ipynb
+++ b/packages/evo-sdk-common/docs/examples/workspace-client.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "# OAuth client app credentials\n",
     "# See: https://developer.seequent.com/docs/guides/getting-started/apps-and-tokens\n",
-    "REDIRECT_URL = \"http://localhost:3000/signin-oidc\"\n",
+    "REDIRECT_URL = \"http://localhost:3000/signin-callback\"\n",
     "CLIENT_NAME = \"Your Client Name\"\n",
     "CLIENT_ID = \"your-client-id\"\n",
     "\n",

--- a/packages/evo-sdk-common/docs/oauth.md
+++ b/packages/evo-sdk-common/docs/oauth.md
@@ -21,7 +21,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # OAuth client app credentials
 # See: https://developer.seequent.com/docs/guides/getting-started/apps-and-tokens
-REDIRECT_URL = "http://localhost:3000/signin-oidc"
+REDIRECT_URL = "http://localhost:3000/signin-callback"
 CLIENT_NAME = "Your Client Name"
 CLIENT_ID = "<client-id>"
 

--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/notebooks/_consts.py
+++ b/packages/evo-sdk-common/src/evo/notebooks/_consts.py
@@ -11,6 +11,6 @@
 
 DEFAULT_DISCOVERY_URL = "https://discover.api.seequent.com"
 DEFAULT_BASE_URI = "https://ims.bentley.com"
-DEFAULT_REDIRECT_URL = "http://localhost:3000/signin-oidc"
+DEFAULT_REDIRECT_URL = "http://localhost:3000/signin-callback"
 
 DEFAULT_CACHE_LOCATION = "./notebook-data"


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

We recently removed OIDC support from evo-sdk-common. This change updates the default redirect URL for notebook examples to `signin-callback` instead of `signin-oidc` to remove any potential confusion.

## Checklist

- [x] I have read the contributing guide and the code of conduct

