### PR TITLE
WS order_by allow both str and enum input

### DIFF
--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -173,7 +173,7 @@ class WorkspaceAPIClient:
         self,
         limit: int | None = None,
         offset: int | None = None,
-        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = None,
+        order_by: dict[WorkspaceOrderByEnum | str, OrderByOperatorEnum | str] | None = None,
         filter_created_by: UUID | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,
@@ -185,7 +185,14 @@ class WorkspaceAPIClient:
         if not offset:
             offset = 0
         if order_by:
-            parsed_order_by = ",".join([f"{op}:{field}" for field, op in order_by.items()])
+            parsed_order_by = ",".join(
+                [
+                    f"{op.value if isinstance(op, OrderByOperatorEnum) else op}:{field.value if isinstance(field, WorkspaceOrderByEnum) else field}"
+                    for field, op in order_by.items()
+                ]
+            )
+        else:
+            parsed_order_by = None
         response = await self._workspaces_api.list_workspaces(
             org_id=str(self._org_id),
             limit=limit,
@@ -247,7 +254,7 @@ class WorkspaceAPIClient:
         self,
         limit: int | None = None,
         offset: int | None = None,
-        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = None,
+        order_by: dict[WorkspaceOrderByEnum | str, OrderByOperatorEnum | str] | None = None,
         filter_created_by: UUID | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,
@@ -261,7 +268,15 @@ class WorkspaceAPIClient:
         This method provides faster performance than list_workspaces() or list_all_workspaces()
         by returning BasicWorkspace objects with minimal data instead of full Workspace objects.
         """
-        parsed_order_by = ",".join([f"{op}:{field}" for field, op in order_by.items()]) if order_by else None
+        if order_by:
+            parsed_order_by = ",".join(
+                [
+                    f"{op.value if isinstance(op, OrderByOperatorEnum) else op}:{field.value if isinstance(field, WorkspaceOrderByEnum) else field}"
+                    for field, op in order_by.items()
+                ]
+            )
+        else:
+            parsed_order_by = None
 
         response = await self._workspaces_api.list_workspaces_summary(
             org_id=str(self._org_id),

--- a/packages/evo-sdk-common/tests/workspaces/test_workspace_client.py
+++ b/packages/evo-sdk-common/tests/workspaces/test_workspace_client.py
@@ -13,6 +13,8 @@ import json
 from unittest import mock
 from uuid import UUID
 
+import pytest
+
 from evo.common import HealthCheckType, RequestMethod
 from evo.common.test_tools import BASE_URL, MockResponse, TestHTTPHeaderDict, TestWithConnector, utc_datetime
 from evo.workspaces import (
@@ -309,6 +311,15 @@ class TestWorkspaceClient(TestWithConnector):
         )
         self.assertEqual([], workspaces.items())
 
+    @pytest.mark.parametrize(
+        "order_by",
+        [
+            {WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc},
+            {WorkspaceOrderByEnum.created_at.value: OrderByOperatorEnum.desc.value},
+            {WorkspaceOrderByEnum.updated_at: OrderByOperatorEnum.asc.value},
+            {WorkspaceOrderByEnum.user_role.value: OrderByOperatorEnum.desc},
+        ],
+    )
     async def test_list_workspaces_summary_all_args(self):
         with self.transport.set_http_response(200, self._empty_content(), headers={"Content-Type": "application/json"}):
             workspaces = await self.workspace_client.list_workspaces_summary(


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

order_by is taking in enum, but is not converted to string before processing them in next layer. This result in 422 as enum instead of str is being passed in. (Issue for python3.11 or higher)

<!-- Describe your proposed changes in detail -->

Allow both str and enum input and client preprocess them into string if is enum being passed in

## Checklist

- [x] I have read the contributing guide and the code of conduct
