### PR TITLE
Move audit out of all evo scope

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "1.0.0"
+version = "0.4.3"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.4.2"
+version = "1.4.2"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "1.4.2"
+version = "1.0.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/oauth/data.py
+++ b/packages/evo-sdk-common/src/evo/oauth/data.py
@@ -68,7 +68,7 @@ class OAuthScopes(Flag):
     default = evo_discovery | evo_workspace
 
     """All scopes for Evo applications."""
-    all_evo = default | evo_blocksync | evo_object | evo_file | evo_audit
+    all_evo = default | evo_blocksync | evo_object | evo_file
 
     def __str__(self) -> str:
         """Format a space-separated list of scopes for the OAuth request."""

--- a/packages/evo-sdk-common/tests/oauth/test_client_credientials_authorizer.py
+++ b/packages/evo-sdk-common/tests/oauth/test_client_credientials_authorizer.py
@@ -41,7 +41,7 @@ class TestClientCredentialsAuthorizer(TestWithOAuthConnector):
         self.assert_token_equals(self.first_token)
         self.assert_fetched_token(
             grant_type="client_credentials",
-            scope="evo.discovery evo.workspace evo.audit evo.blocksync evo.object evo.file",
+            scope="evo.discovery evo.workspace evo.blocksync evo.object evo.file",
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
         )
@@ -54,7 +54,7 @@ class TestClientCredentialsAuthorizer(TestWithOAuthConnector):
         self.assertTrue(result)
         self.assert_fetched_token(
             grant_type="client_credentials",
-            scope="evo.discovery evo.workspace evo.audit evo.blocksync evo.object evo.file",
+            scope="evo.discovery evo.workspace evo.blocksync evo.object evo.file",
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
         )

--- a/packages/evo-sdk-common/tests/oauth/test_data.py
+++ b/packages/evo-sdk-common/tests/oauth/test_data.py
@@ -77,7 +77,6 @@ class TestOAuthScopes(unittest.TestCase):
                     OAuthScopes.evo_blocksync,
                     OAuthScopes.evo_object,
                     OAuthScopes.evo_file,
-                    OAuthScopes.evo_audit,
                 ),
             ),
         ],

--- a/uv.lock
+++ b/uv.lock
@@ -777,7 +777,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "1.0.0"
+version = "0.4.3"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },

--- a/uv.lock
+++ b/uv.lock
@@ -777,7 +777,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "1.4.2"
+version = "1.0.0"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },

--- a/uv.lock
+++ b/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 
 [[package]]
 name = "evo-files"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/evo-files" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -649,7 +649,7 @@ test = [
 
 [[package]]
 name = "evo-objects"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/evo-objects" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -722,7 +722,7 @@ test = [
 
 [[package]]
 name = "evo-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "evo-files", extra = ["aiohttp", "notebooks"] },
@@ -777,7 +777,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.4.1"
+version = "1.4.2"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->
As audit scope is not configured for all entities that uses all_evo scope, moving the audit out will tackle the issue for those entity getting error during scope check.


## Checklist

- [x] I have read the contributing guide and the code of conduct
