### PR TITLE
Enable zero-byte uploads for Chunked IO Manager

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.6"
+version = "0.5.7"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/io/chunked_io_manager.py
+++ b/packages/evo-sdk-common/src/evo/common/io/chunked_io_manager.py
@@ -93,6 +93,8 @@ class ChunkedIOTracker:
 
         :return: A float between 0 and 1 representing the progress, rounded to 2 decimal places.
         """
+        if self._n_chunks == 0:
+            return 1.0
         return round(self._n_chunks_completed / self._n_chunks, 2)
 
     def is_complete(self) -> bool:

--- a/packages/evo-sdk-common/tests/common/io/test_chunked_io_manager.py
+++ b/packages/evo-sdk-common/tests/common/io/test_chunked_io_manager.py
@@ -262,3 +262,18 @@ class TestChunkedIOManager(unittest.IsolatedAsyncioTestCase):
 
         # Verify results.
         self.assertFalse(self.manager.is_complete())
+
+    async def test_zero_byte_file(self) -> None:
+        # Create and verify source.
+        source = _TestIO(content=b"", expires_after=self.EXPIRES_AFTER)
+        self.assertEqual(b"", source.get_raw_content())
+
+        # Create and verify destination.
+        destination = _TestIO()
+        self.assertEqual(b"", destination.get_raw_content())
+
+        # Transfer data.
+        await self.manager.run(source, destination)
+
+        # Verify results.
+        self.assertTrue(self.manager.is_complete())


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description
Resolved a bug with ChunkedIOManager where if the file size was 0 bytes, the upload failed with a divide by zero error.

## Checklist

- [X] I have read the contributing guide and the code of conduct
