### PR TITLE
Add common utils function for retrieving package details

### DIFF
--- a/packages/evo-sdk-common/src/evo/common/utils/__init__.py
+++ b/packages/evo-sdk-common/src/evo/common/utils/__init__.py
@@ -14,6 +14,7 @@ from .data import parse_order_by
 from .feedback import NoFeedback, PartialFeedback, iter_with_fb
 from .health_check import get_service_health, get_service_status
 from .retry import BackoffExponential, BackoffIncremental, BackoffLinear, BackoffMethod, Retry, RetryHandler
+from .verison import get_package_details
 
 __all__ = [
     "BackoffExponential",
@@ -25,6 +26,7 @@ __all__ = [
     "PartialFeedback",
     "Retry",
     "RetryHandler",
+    "get_package_details",
     "get_service_health",
     "get_service_status",
     "iter_with_fb",

--- a/packages/evo-sdk-common/src/evo/common/utils/verison.py
+++ b/packages/evo-sdk-common/src/evo/common/utils/verison.py
@@ -1,0 +1,39 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import functools
+from importlib import metadata
+
+__all__ = ["get_package_details"]
+
+
+@functools.cache
+def get_package_details(candidate: str) -> dict:
+    """Get package name and version given the module __name__.
+
+    :param candidate: The module __name__ to start searching from.
+
+    :return: A dictionary containing the package name and version.
+
+    :raises metadata.PackageNotFoundError: If no package could be found.
+    """
+    while candidate:
+        try:
+            package_metadata = metadata.metadata(candidate)
+        except metadata.PackageNotFoundError:
+            candidate, *_ = candidate.rpartition(".")
+        else:
+            return {
+                "name": package_metadata["name"],
+                "version": package_metadata["version"],
+            }
+
+    raise metadata.PackageNotFoundError(__package__)


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

This function returns a dictionary containing name and version for a given module __name__. This will be used for adding SDK version metadata to headers when calling APIs from their respective endpoints. Thanks to @wordsworthc for the suggestion!

## Checklist

- [x] I have read the contributing guide and the code of conduct
