### PR TITLE
Expose file_id and version_id properties in the return type from prepare_upload_by_id/prepare_upload_by_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## evo-sdk@v0.1.12
+### What's changed
+#### evo-sdk
+* Expose file_id and version_id properties in the return type of prepare_upload_by_id/prepare_upload_by_path by @BenLewis-Seequent in https://github.com/SeequentEvo/evo-python-sdk/pull/132
+
+**Full changelog**: https://github.com/SeequentEvo/evo-python-sdk/compare/evo-sdk@v0.1.11...evo-sdk@v0.1.12
+
+## evo-files@v0.2.2
+### What's changed
+#### evo-files
+* Expose file_id and version_id properties in the return type of prepare_upload_by_id/prepare_upload_by_path by @BenLewis-Seequent in https://github.com/SeequentEvo/evo-python-sdk/pull/132
+
+**Full changelog**: https://github.com/SeequentEvo/evo-python-sdk/compare/evo-files@v0.2.1...evo-files@v0.2.2
+
 ## evo-sdk@v0.1.11
 ### What's changed
 #### evo-sdk

--- a/packages/evo-files/pyproject.toml
+++ b/packages/evo-files/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-files"
 description = "Python SDK for using the Seequent Evo File API"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-files/src/evo/files/io.py
+++ b/packages/evo-files/src/evo/files/io.py
@@ -110,8 +110,18 @@ class FileAPIUpload(Upload, _FileIOMixin):
         self._version_id = version_id
 
     @property
+    def file_id(self) -> UUID:
+        """The ID of the file that is being uploaded."""
+        return self._id
+
+    @property
+    def version_id(self) -> str:
+        """The ID of the version that will be created after the upload completes."""
+        return self._version_id
+
+    @property
     def label(self) -> str:
-        """The file and version ID for the file that is being uploaded."""
+        """The file and version ID of the file that is being uploaded."""
         return f"{self._id}?version_id={self._version_id}"
 
     async def get_upload_url(self) -> str:

--- a/packages/evo-files/tests/test_file_api_client.py
+++ b/packages/evo-files/tests/test_file_api_client.py
@@ -486,8 +486,8 @@ class TestFileApiClient(TestWithConnector):
             upload = await self.file_api_client.prepare_upload_by_path("points.csv")
 
         self.assertIsInstance(upload, FileAPIUpload)
-        self.assertEqual(upsert_file_response["file_id"], str(upload._id))
-        self.assertEqual(upsert_file_response["version_id"], upload._version_id)
+        self.assertEqual(upsert_file_response["file_id"], str(upload.file_id))
+        self.assertEqual(upsert_file_response["version_id"], upload.version_id)
         self.assert_request_made(
             method=RequestMethod.PUT,
             path=f"{self.base_path}/files/path/points.csv",
@@ -503,8 +503,8 @@ class TestFileApiClient(TestWithConnector):
             upload = await self.file_api_client.prepare_upload_by_id(file_id)
 
         self.assertIsInstance(upload, FileAPIUpload)
-        self.assertEqual(update_file_response["file_id"], str(upload._id))
-        self.assertEqual(update_file_response["version_id"], upload._version_id)
+        self.assertEqual(update_file_response["file_id"], str(upload.file_id))
+        self.assertEqual(update_file_response["version_id"], upload.version_id)
         self.assert_request_made(
             method=RequestMethod.PUT,
             path=f"{self.base_path}/files/{file_id}",

--- a/packages/evo-files/tests/test_file_io.py
+++ b/packages/evo-files/tests/test_file_io.py
@@ -126,6 +126,12 @@ class TestFileAPIUpload(TestWithConnector, TestWithUploadHandler):
         expected = f"{FILE_ID}?version_id={VERSION_ID}"
         self.assertEqual(expected, self.upload.label)
 
+    def test_file_id(self) -> None:
+        self.assertEqual(self.upload.file_id, FILE_ID)
+
+    def test_version_id(self) -> None:
+        self.assertEqual(self.upload.version_id, VERSION_ID)
+
     async def test_get_upload_url(self) -> None:
         # Test the initial URL is used first.
         first = await self.upload.get_upload_url()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-sdk"
-version = "0.1.11"
+version = "0.1.12"
 description = "Python SDK for using Seequent Evo"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "evo-blockmodels"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "packages/evo-blockmodels" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -723,7 +723,7 @@ test = [
 
 [[package]]
 name = "evo-files"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/evo-files" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -865,7 +865,7 @@ test = [
 
 [[package]]
 name = "evo-sdk"
-version = "0.1.10"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "evo-blockmodels", extra = ["aiohttp", "notebooks", "pyarrow"] },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

Add `file_id` and `version_id` properties to `FileAPIUpload`, to be able to retrieve that information without parsing the `label` property. 

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
