### PR TITLE
Add a method to rename blockmodel columns to the SDK

### DIFF
--- a/packages/evo-blockmodels/docs/examples/quickstart.ipynb
+++ b/packages/evo-blockmodels/docs/examples/quickstart.ipynb
@@ -212,6 +212,32 @@
     "    f\"Updated version: id={version_after_update.version_id}, uuid={version_after_update.version_uuid}, comment={version_after_update.comment}\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rename Block Model Columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rename existing columns in the block model\n",
+    "# This example renames columns to more descriptive names\n",
+    "version_after_rename = await service_client.rename_block_model_columns(\n",
+    "    bm_id=block_model.id,\n",
+    "    column_renames={\"column_one\": \"geology_type\", \"column_two\": \"assay_value\"},\n",
+    "    comment=\"Renamed columns for clarity and consistency\",\n",
+    ")\n",
+    "\n",
+    "print(\n",
+    "    f\"Renamed version: id={version_after_rename.version_id}, uuid={version_after_rename.version_uuid}, comment={version_after_rename.comment}\"\n",
+    ")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description

Add a method to the blockmodel SDK to make it easy to rename columns. Includes an example of how to do this in the quickstart notebook.
One of the requested features from https://github.com/SeequentEvo/evo-python-sdk/issues/133

## Checklist

- [x] I have read the contributing guide and the code of conduct
