### PR TITLE
Add a method for deleting columns

### DIFF
--- a/packages/evo-blockmodels/docs/examples/quickstart.ipynb
+++ b/packages/evo-blockmodels/docs/examples/quickstart.ipynb
@@ -238,6 +238,32 @@
     "    f\"Renamed version: id={version_after_rename.version_id}, uuid={version_after_rename.version_uuid}, comment={version_after_rename.comment}\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete Block Model Columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete columns from a block model\n",
+    "# This example deletes two columns and records a comment on the new version.\n",
+    "version_after_delete = await service_client.delete_block_model_columns(\n",
+    "    bm_id=block_model.id,\n",
+    "    column_titles=[\"column_three\", \"column_four\"],\n",
+    "    comment=\"Remove temporary columns\",\n",
+    ")\n",
+    "\n",
+    "print(\n",
+    "    f\"After delete: id={version_after_delete.version_id}, uuid={version_after_delete.version_uuid}, comment={version_after_delete.comment}\"\n",
+    ")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description

Add a method for renaming columns. As there are now 3 methods for updating columns without data, move common functionality to a shared function.
Adds an example of deleting columns to the jupyter notebook.

One of the requested features from https://github.com/SeequentEvo/evo-python-sdk/issues/133

## Checklist

- [x] I have read the contributing guide and the code of conduct
