### PR TITLE
Update metadata headers to a more standardised format

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.10"
+version = "0.5.11"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/utils/version.py
+++ b/packages/evo-sdk-common/src/evo/common/utils/version.py
@@ -27,10 +27,10 @@ def get_header_metadata(candidate: str) -> dict[str, str]:
 
     :param candidate: The module __name__ to start searching from.
 
-    :return: A dictionary containing the package name and version in a single entry.
+    :return: A dictionary with a value containing the package name and version.
     """
     package_details = get_package_details(candidate)
-    return {package_details.name: package_details.version}
+    return {"Evo-SDK-Source": f"{package_details.name}@v{package_details.version}"}
 
 
 @functools.cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-sdk"
-version = "0.1.15"
+version = "0.1.16"
 description = "Python SDK for using Seequent Evo"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

Before, the metadata headers looked like:
`{evo-blockmodels: 0.1.0}`

Now, they look like this:
`{Evo-SDK-Source: evo-blockmodels@v0.1.0}`

This way, we only have to look for the "Evo-SDK-Source" key for making use of these metadata headers, and won't have to update how we look for these upon each new package release.

## Checklist

- [x] I have read the contributing guide and the code of conduct
