### PR TITLE
TargetWorkspaceSelectorWidget Fix

### DIFF
--- a/samples/workspaces/bonus/workspace_utils.py
+++ b/samples/workspaces/bonus/workspace_utils.py
@@ -221,8 +221,7 @@ class TargetWorkspaceSelectorWidget:
         # Get the selected workspace ID
         selected_id = manager_widget._workspace_selector.selected
 
-        _NULL_UUID = UUID(int=0)
-        if selected_id != _NULL_UUID:
+        if selected_id != manager_widget._workspace_selector.UNSELECTED[1]:
             self.current_workspace_id = selected_id
         else:
             raise ValueError("No source workspace is currently selected.")


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

A simple fix to display the appropriate selected source workspace name under TargetWorkspaceSelectorWidget. 

## Checklist

- [x] I have read the contributing guide and the code of conduct
