### PR TITLE
Update samples to use latest evo-schemas version

### DIFF
--- a/samples/pyproject.toml
+++ b/samples/pyproject.toml
@@ -5,7 +5,7 @@ description = "Code samples for the Seequent Evo Python SDK"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "evo-schemas>=2025.9.12",
+    "evo-schemas>=2025.12.15",
     "evo-sdk>=0.1.17",
     "geosoft>=2025.1.1 ; sys_platform == 'windows'",
     "jupyterlab>=4.3.6",

--- a/samples/uv.lock
+++ b/samples/uv.lock
@@ -557,14 +557,14 @@ utils = [
 
 [[package]]
 name = "evo-schemas"
-version = "2025.9.12"
+version = "2025.12.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpointer" },
     { name = "rfc3986-validator" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/a1/c63b098e8e20a0572dfc7971fa26ced78567b1c5f708a5ba7c0f91c07d63/evo_schemas-2025.9.12-py3-none-any.whl", hash = "sha256:e183c0c2efb772c8b7e645557c9eabedb4747082f06c3342842d5dc4515cafbf", size = 490710, upload-time = "2025-09-11T22:22:35.818Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/47/76ed5353dc433a4d0e263a3df32b804a2b7418461f1f297733d16670181c/evo_schemas-2025.12.15-py3-none-any.whl", hash = "sha256:1eac7a784a54f9d1584302468baf6e537163c13665b26f14b30a183daae59e44", size = 534117, upload-time = "2025-12-15T22:00:30.808Z" },
 ]
 
 [[package]]
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "evo-schemas", specifier = ">=2025.9.12" },
+    { name = "evo-schemas", specifier = ">=2025.12.15" },
     { name = "evo-sdk", specifier = ">=0.1.17" },
     { name = "geosoft", marker = "sys_platform == 'windows'", specifier = ">=2025.1.1" },
     { name = "jupyterlab", specifier = ">=4.3.6" },


### PR DESCRIPTION
## Description

Updated `/samples` to use latest evo-schemas version. This allows the samples to make use the enhanced docstrings for evo-schemas classes. Before, limited or no information would be visible inside the IDE on hover for evo-schemas classes, but now there's a detailed docstring containing attributes/inputs.

## Checklist

- [x] I have read the contributing guide and the code of conduct
