### PR TITLE
Escape error message before _build_redirect_html_failed

### DIFF
--- a/packages/evo-sdk-common/src/evo/oauth/oauth_redirect_handler.py
+++ b/packages/evo-sdk-common/src/evo/oauth/oauth_redirect_handler.py
@@ -190,7 +190,7 @@ class OAuthRedirectHandler:
             if "error" in request.query:  # Check for an error response from the OAuth provider.
                 title = request.query.getone("error")  # Raises KeyError if `error` is missing.
                 detail = request.query.getone("error_description", None)
-                error_message = detail or title or ""
+                error_message = detail or title or "unknown"
                 await response.write(_build_redirect_html_failed(html.escape(error_message)))
                 raise OAuthError(error_message)  # Report the more detailed error message if it is available.
 


### PR DESCRIPTION
## Description

Escaping this error message before _build_redirect_html_failed is called so it can be detected as fixed by the code scanning.

## Checklist

- [x] I have read the contributing guide and the code of conduct
