### PR TITLE
Adding worskpaces maintainers code owner group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@
 # PACKAGE-SPECIFIC MAINTAINERS
 # =============================================================================
 
-packages/evo-blockmodels/     @SeequentEvo/blockmodels-maintainers
-packages/evo-colormaps/       @SeequentEvo/colormaps-maintainers
-packages/evo-compute/         @SeequentEvo/compute-maintainers
-packages/evo-files/           @SeequentEvo/files-maintainers
-packages/evo-objects/         @SeequentEvo/objects-maintainers
-packages/evo-sdk-common/      @SeequentEvo/python-sdk-common-maintainers
+packages/evo-blockmodels/                   @SeequentEvo/blockmodels-maintainers
+packages/evo-colormaps/                     @SeequentEvo/colormaps-maintainers
+packages/evo-compute/                       @SeequentEvo/compute-maintainers
+packages/evo-files/                         @SeequentEvo/files-maintainers
+packages/evo-objects/                       @SeequentEvo/objects-maintainers
+packages/evo-sdk-common/                    @SeequentEvo/python-sdk-common-maintainers
 packages/evo-sdk-common/src/evo/workspaces/ @SeequentEvo/workspaces-maintainers


### PR DESCRIPTION
Adding the workspaces team as code owners for the workspaces module

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
