### PR TITLE
Make version field optional in service health check response

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.13"
+version = "0.5.14"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/utils/health_check.py
+++ b/packages/evo-sdk-common/src/evo/common/utils/health_check.py
@@ -73,10 +73,10 @@ def _parse_service_health_dict(service_name: str, status_code: int, response: di
     """
     try:
         status_str = response["status"]
-        version = response["version"]
     except KeyError as err:
         raise ClientValueError("Service health response must include a status.") from err
 
+    version = response.get("version")
     service_status = _parse_service_status(status_str)
 
     dependencies = None


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

- Make version field optional in service health check response

## Checklist

- [x] I have read the contributing guide and the code of conduct
