### PR TITLE
HTTPIOBase static method additional headers

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.17"
+version = "0.5.18"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/io/http.py
+++ b/packages/evo-sdk-common/src/evo/common/io/http.py
@@ -299,8 +299,8 @@ class HTTPSource(HTTPIOBase, ISource):
         :param retry: A Retry object with a wait strategy. If None, a default Retry is created. If a chunk is successfully
             transferred the attempt counter will be reset.
         :param overwrite: whether to overwrite an existing local file
-        :param fb: feedback to track the download, by tracking writes to the file
         :param additional_headers: Additional headers to include in each request.
+        :param fb: feedback to track the download, by tracking writes to the file
 
         :raises FileNameTooLongError: If the filename is too long.
         :raises ValueError: if the file already exists and overwrite is False

--- a/packages/evo-sdk-common/src/evo/common/io/http.py
+++ b/packages/evo-sdk-common/src/evo/common/io/http.py
@@ -283,6 +283,7 @@ class HTTPSource(HTTPIOBase, ISource):
         max_workers: int | None = None,
         retry: Retry | None = None,
         overwrite: bool = False,
+        additional_headers: dict[str, str] | None = None,
         fb: IFeedback = NoFeedback,
     ) -> None:
         """Download an HTTP resource to a file with the given filename.
@@ -299,6 +300,7 @@ class HTTPSource(HTTPIOBase, ISource):
             transferred the attempt counter will be reset.
         :param overwrite: whether to overwrite an existing local file
         :param fb: feedback to track the download, by tracking writes to the file
+        :param additional_headers: Additional headers to include in each request.
 
         :raises FileNameTooLongError: If the filename is too long.
         :raises ValueError: if the file already exists and overwrite is False
@@ -314,7 +316,7 @@ class HTTPSource(HTTPIOBase, ISource):
             retry = Retry(logger=logger)
         manager = ChunkedIOManager(retry=retry, max_workers=max_workers)
 
-        async with HTTPSource(url_generator, transport) as source:
+        async with HTTPSource(url_generator, transport, additional_headers=additional_headers) as source:
             tmp_file = None
             try:
                 with NamedTemporaryFile(delete=False, dir=dst_path.parent) as tmp_file:

--- a/packages/evo-sdk-common/src/evo/common/io/storage.py
+++ b/packages/evo-sdk-common/src/evo/common/io/storage.py
@@ -185,6 +185,7 @@ class StorageDestination(HTTPIOBase, IDestination):
         transport: ITransport,
         max_workers: int | None = None,
         retry: Retry | None = None,
+        additional_headers: dict[str, str] | None = None,
         fb: IFeedback | None = None,
     ) -> None:
         """Upload a file with the given filename to the given Storage URL.
@@ -200,6 +201,7 @@ class StorageDestination(HTTPIOBase, IDestination):
         :param retry: A Retry object with a wait strategy. If None, a default Retry is created. If a chunk is successfully
             transferred the attempt counter will be reset.
         :param fb: feedback to track the upload, by tracking reads from the file only
+        :param additional_headers: Additional headers to include in each request.
 
         :raises ValueError: if the file to upload does not exist
         :raises ChunkedIOException: if a non-recoverable exception occurred.
@@ -215,7 +217,9 @@ class StorageDestination(HTTPIOBase, IDestination):
             retry = Retry(logger=logger)
 
         manager = ChunkedIOManager(message="Uploading", retry=retry, max_workers=max_workers)
-        async with StorageDestination(url_callback=url_generator, transport=transport) as destination:
+        async with StorageDestination(
+            url_callback=url_generator, transport=transport, additional_headers=additional_headers
+        ) as destination:
             size = os.path.getsize(src_path)
             with src_path.open("rb") as input_:
                 source = BytesSource(input_, size)

--- a/packages/evo-sdk-common/src/evo/common/io/storage.py
+++ b/packages/evo-sdk-common/src/evo/common/io/storage.py
@@ -200,8 +200,8 @@ class StorageDestination(HTTPIOBase, IDestination):
             is `min(32, os.cpu_count() + 4)`
         :param retry: A Retry object with a wait strategy. If None, a default Retry is created. If a chunk is successfully
             transferred the attempt counter will be reset.
-        :param fb: feedback to track the upload, by tracking reads from the file only
         :param additional_headers: Additional headers to include in each request.
+        :param fb: feedback to track the upload, by tracking reads from the file only
 
         :raises ValueError: if the file to upload does not exist
         :raises ChunkedIOException: if a non-recoverable exception occurred.

--- a/packages/evo-sdk-common/tests/common/io/test_http.py
+++ b/packages/evo-sdk-common/tests/common/io/test_http.py
@@ -89,6 +89,22 @@ class TestHTTPSource(TestISource, TestWithDownloadHandler):
             call_kwargs = mock_api_connector.call_args.kwargs
             self.assertEqual(additional_headers, call_kwargs.get("additional_headers"))
 
+    @mock.patch("evo.common.io.http.APIConnector", wraps=APIConnector)
+    async def test_download_file_passes_additional_headers_to_connector(self, mock_api_connector: mock.Mock) -> None:
+        """Test that download_file passes additional headers through to APIConnector."""
+        additional_headers = {"X-Custom-Header": "custom-value", "X-Another-Header": "another-value"}
+        test_data_file = self.CACHE_DIR / "test_data_download_headers.csv"
+
+        await HTTPSource.download_file(
+            test_data_file,
+            self.url_generator.get_new_url,
+            self.transport,
+            additional_headers=additional_headers,
+        )
+
+        mock_api_connector.assert_called_once()
+        self.assertEqual(additional_headers, mock_api_connector.call_args.kwargs.get("additional_headers"))
+
 
 # Delete base test classes to prevent discovery by unittest.
 del TestISource

--- a/packages/evo-sdk-common/tests/common/io/test_storage.py
+++ b/packages/evo-sdk-common/tests/common/io/test_storage.py
@@ -210,6 +210,23 @@ class TestStorageDestination(TestIDestination, TestWithUploadHandler):
             call_kwargs = mock_api_connector.call_args.kwargs
             self.assertEqual(additional_headers, call_kwargs.get("additional_headers"))
 
+    @mock.patch("evo.common.io.http.APIConnector", wraps=APIConnector)
+    async def test_upload_file_passes_additional_headers_to_connector(self, mock_api_connector: mock.Mock) -> None:
+        """Test that upload_file passes additional headers through to APIConnector."""
+        additional_headers = {"X-Custom-Header": "custom-value", "X-Another-Header": "another-value"}
+        test_data_file = self.CACHE_DIR / "test_data_upload_headers.csv"
+        test_data_file.write_bytes(TEST_DATA)
+
+        await StorageDestination.upload_file(
+            test_data_file,
+            self.url_generator.get_new_url,
+            self.transport,
+            additional_headers=additional_headers,
+        )
+
+        mock_api_connector.assert_called_once()
+        self.assertEqual(additional_headers, mock_api_connector.call_args.kwargs.get("additional_headers"))
+
 
 # Delete base test classes to prevent discovery by unittest.
 del TestIDestination

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-sdk"
-version = "0.1.19"
+version = "0.1.20"
 description = "Python SDK for using Seequent Evo"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1071,7 +1071,7 @@ test = [
 
 [[package]]
 name = "evo-sdk"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "evo-blockmodels", extra = ["aiohttp", "notebooks", "pyarrow"] },
@@ -1134,7 +1134,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.5.16"
+version = "0.5.17"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
Allow the additional headers to be passed to the HTTPIOBase subclasses static methods.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
