### PR TITLE
Cast large_string to string right before saving to Parquet.

### DIFF
--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.4.1"
+version = "0.4.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -203,7 +203,7 @@ class ObjectDataClient:
         columns_chunk_range = []
         for column in table.itercolumns():
             column = column.dictionary_encode()
-            if not (pa.types.is_string(column.type.value_type) or pa.types.is_large_string(column.type.value_type)):
+            if not pa.types.is_string(column.type.value_type):
                 raise TableFormatError("Category columns must be of type string")
             if not pa.types.is_int32(column.type.index_type):
                 # Currently, we only support int32 indices
@@ -231,8 +231,6 @@ class ObjectDataClient:
         )
 
         dictionary_values = all_chunks[0].dictionary
-        if pa.types.is_large_string(dictionary_values.type):
-            dictionary_values = pc.cast(dictionary_values, pa.string())
         lookup = pa.Table.from_arrays(
             [np.arange(len(dictionary_values), dtype=np.int32), dictionary_values], names=["key", "value"]
         )

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -67,6 +67,22 @@ def _iter_refs(target: Any, _key: str | None = None) -> Iterator[str]:
             yield str(value)
 
 
+def _cast_large_strings(table: pa.Table) -> pa.Table:
+    """Cast any large_string columns in the table to string.
+
+    Pandas 3+ with pyarrow-backed string dtype produces large_string columns
+    when converting to Arrow, which downstream consumers may not support.
+    """
+    for i, field in enumerate(table.schema):
+        if pa.types.is_large_string(field.type):
+            table = table.set_column(i, field.name, table.column(i).cast(pa.string()))
+        elif pa.types.is_dictionary(field.type) and pa.types.is_large_string(field.type.value_type):
+            table = table.set_column(
+                i, field.name, table.column(i).cast(pa.dictionary(field.type.index_type, pa.string()))
+            )
+    return table
+
+
 class ObjectDataClient:
     """An optional wrapper around data upload and download functionality for geoscience objects.
 
@@ -298,7 +314,8 @@ class ObjectDataClient:
                 no table formats are specified, raised when the table does not match any known format.
             :raises StorageFileNotFoundError: If the destination does not exist or is not a directory.
             """
-            return self.save_table(pa.Table.from_pandas(dataframe), table_format=table_format)
+            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            return self.save_table(table, table_format=table_format)
 
         async def upload_dataframe(
             self,
@@ -320,7 +337,8 @@ class ObjectDataClient:
             :raises TableFormatError: If the provided table does not match any of the specified formats. If
                 no table formats are specified, raised when the table does not match any known format.
             """
-            table_info = await self.upload_table(pa.Table.from_pandas(dataframe), table_format=table_format, fb=fb)
+            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            table_info = await self.upload_table(table, table_format=table_format, fb=fb)
             return table_info
 
         async def upload_category_dataframe(self, dataframe: pd.DataFrame, fb: IFeedback = NoFeedback) -> CategoryInfo:
@@ -340,7 +358,8 @@ class ObjectDataClient:
             :raises TableFormatError: If the table isn't a valid category table, or if the number of categories exceeds
                 what int32 type can represent.
             """
-            category_info = await self.upload_category_table(pa.Table.from_pandas(dataframe), fb=fb)
+            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            category_info = await self.upload_category_table(table, fb=fb)
             return category_info
 
         async def download_dataframe(

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -72,6 +72,9 @@ def _cast_large_strings(table: pa.Table) -> pa.Table:
 
     Pandas 3+ with pyarrow-backed string dtype produces large_string columns
     when converting to Arrow, which downstream consumers may not support.
+
+    :param table: The Arrow table to cast.
+    :return: The Arrow table with large_string columns cast to string.
     """
     for i, field in enumerate(table.schema):
         if pa.types.is_large_string(field.type):

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -67,23 +67,27 @@ def _iter_refs(target: Any, _key: str | None = None) -> Iterator[str]:
             yield str(value)
 
 
-def _cast_large_strings(table: pa.Table) -> pa.Table:
-    """Cast any large_string columns in the table to string.
+def _get_schema_from_dataframe(dataframe: "pd.DataFrame") -> pa.Schema:
+    """Get a normalized pyarrow schema from a pandas dataframe.
 
-    Pandas 3+ with pyarrow-backed string dtype produces large_string columns
-    when converting to Arrow, which downstream consumers may not support.
+    This hook centralizes dataframe-to-Arrow schema adjustments before the
+    dataframe is converted to a table. It currently performs these conversions:
+    - large_string -> string
+    - dictionary<index, large_string> -> dictionary<index, string>
 
-    :param table: The Arrow table to cast.
-    :return: The Arrow table with large_string columns cast to string.
+    :param dataframe: The pandas dataframe to get the schema from.
+    :return: A pyarrow schema with any configured type conversions applied.
     """
-    for i, field in enumerate(table.schema):
+    schema = pa.Schema.from_pandas(dataframe)
+    fields = []
+    for field in schema:
         if pa.types.is_large_string(field.type):
-            table = table.set_column(i, field.name, table.column(i).cast(pa.string()))
+            fields.append(field.with_type(pa.string()))
         elif pa.types.is_dictionary(field.type) and pa.types.is_large_string(field.type.value_type):
-            table = table.set_column(
-                i, field.name, table.column(i).cast(pa.dictionary(field.type.index_type, pa.string()))
-            )
-    return table
+            fields.append(field.with_type(pa.dictionary(field.type.index_type, pa.string())))
+        else:
+            fields.append(field)
+    return pa.schema(fields)
 
 
 class ObjectDataClient:
@@ -317,7 +321,8 @@ class ObjectDataClient:
                 no table formats are specified, raised when the table does not match any known format.
             :raises StorageFileNotFoundError: If the destination does not exist or is not a directory.
             """
-            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            schema = _get_schema_from_dataframe(dataframe)
+            table = pa.Table.from_pandas(dataframe, schema)
             return self.save_table(table, table_format=table_format)
 
         async def upload_dataframe(
@@ -340,7 +345,8 @@ class ObjectDataClient:
             :raises TableFormatError: If the provided table does not match any of the specified formats. If
                 no table formats are specified, raised when the table does not match any known format.
             """
-            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            schema = _get_schema_from_dataframe(dataframe)
+            table = pa.Table.from_pandas(dataframe, schema)
             table_info = await self.upload_table(table, table_format=table_format, fb=fb)
             return table_info
 
@@ -361,7 +367,8 @@ class ObjectDataClient:
             :raises TableFormatError: If the table isn't a valid category table, or if the number of categories exceeds
                 what int32 type can represent.
             """
-            table = _cast_large_strings(pa.Table.from_pandas(dataframe))
+            schema = _get_schema_from_dataframe(dataframe)
+            table = pa.Table.from_pandas(dataframe, schema)
             category_info = await self.upload_category_table(table, fb=fb)
             return category_info
 

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -73,7 +73,6 @@ def _get_schema_from_dataframe(dataframe: "pd.DataFrame") -> pa.Schema:
     This hook centralizes dataframe-to-Arrow schema adjustments before the
     dataframe is converted to a table. It currently performs these conversions:
     - large_string -> string
-    - dictionary<index, large_string> -> dictionary<index, string>
 
     :param dataframe: The pandas dataframe to get the schema from.
     :return: A pyarrow schema with any configured type conversions applied.
@@ -83,8 +82,6 @@ def _get_schema_from_dataframe(dataframe: "pd.DataFrame") -> pa.Schema:
     for field in schema:
         if pa.types.is_large_string(field.type):
             fields.append(field.with_type(pa.string()))
-        elif pa.types.is_dictionary(field.type) and pa.types.is_large_string(field.type.value_type):
-            fields.append(field.with_type(pa.dictionary(field.type.index_type, pa.string())))
         else:
             fields.append(field)
     return pa.schema(fields)

--- a/packages/evo-objects/src/evo/objects/utils/tables.py
+++ b/packages/evo-objects/src/evo/objects/utils/tables.py
@@ -64,7 +64,7 @@ class _ColumnFormat:
                 return pa.int64()
             case "bool":
                 return pa.bool_()
-            case "string" | "large_string":
+            case "string":
                 return pa.string()
             case "timestamp":
                 return pa.timestamp("us", tz="UTC")
@@ -88,7 +88,7 @@ class _ColumnFormat:
                 return "int64"
             case "bool":
                 return "bool"
-            case "string" | "large_string":
+            case "string":
                 return "string"
             case "timestamp[us, tz=UTC]":
                 return "timestamp"

--- a/packages/evo-objects/tests/test_data_client.py
+++ b/packages/evo-objects/tests/test_data_client.py
@@ -113,7 +113,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination") as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
-            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
+            mock.patch("evo.objects.utils.data._get_schema_from_dataframe", return_value=None),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -263,7 +263,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination", autospec=True) as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
-            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
+            mock.patch("evo.objects.utils.data._get_schema_from_dataframe", return_value=None),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -352,7 +352,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination", autospec=True) as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
-            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
+            mock.patch("evo.objects.utils.data._get_schema_from_dataframe", return_value=None),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -553,8 +553,8 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
         self.assertEqual(category_info["values"]["table"], values_table)
         self.assertEqual(category_info["values"]["table_format"], values_table_format)
 
-    async def test_upload_dataframe_casts_large_string(self) -> None:
-        """Test that upload_dataframe casts large_string columns (from pandas string[pyarrow]) to string."""
+    async def test_upload_dataframe_converts_large_string_via_schema(self) -> None:
+        """Test that upload_dataframe converts large_string columns (from pandas string[pyarrow]) to string via schema."""
         dataframe = pd.DataFrame({"col": pd.Series(["A", "B", "C"], dtype="string[pyarrow]")})
         with mock.patch.object(self.data_client, "upload_table", new_callable=mock.AsyncMock) as mock_upload:
             mock_upload.return_value = {}
@@ -563,8 +563,8 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
         (table,), _ = mock_upload.await_args
         self.assertTrue(pa.types.is_string(table.schema.field("col").type))
 
-    async def test_upload_category_dataframe_casts_large_string_categories(self) -> None:
-        """Test that upload_category_dataframe casts large_string categories (from pandas string[pyarrow]) to string."""
+    async def test_upload_category_dataframe_converts_large_string_categories_via_schema(self) -> None:
+        """Test that upload_category_dataframe converts large_string categories (from pandas string[pyarrow]) to string via schema."""
         dataframe = pd.DataFrame({"Category": pd.Categorical(pd.Series(["A", "B", "A", "C"], dtype="string[pyarrow]"))})
         with mock.patch.object(self.data_client, "upload_category_table", new_callable=mock.AsyncMock) as mock_upload:
             mock_upload.return_value = {}

--- a/packages/evo-objects/tests/test_data_client.py
+++ b/packages/evo-objects/tests/test_data_client.py
@@ -565,12 +565,8 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
 
     async def test_upload_category_dataframe_casts_large_string_categories(self) -> None:
         """Test that upload_category_dataframe casts large_string categories (from pandas string[pyarrow]) to string."""
-        dataframe = pd.DataFrame(
-            {"Category": pd.Categorical(pd.Series(["A", "B", "A", "C"], dtype="string[pyarrow]"))}
-        )
-        with mock.patch.object(
-            self.data_client, "upload_category_table", new_callable=mock.AsyncMock
-        ) as mock_upload:
+        dataframe = pd.DataFrame({"Category": pd.Categorical(pd.Series(["A", "B", "A", "C"], dtype="string[pyarrow]"))})
+        with mock.patch.object(self.data_client, "upload_category_table", new_callable=mock.AsyncMock) as mock_upload:
             mock_upload.return_value = {}
             await self.data_client.upload_category_dataframe(dataframe)
 

--- a/packages/evo-objects/tests/test_data_client.py
+++ b/packages/evo-objects/tests/test_data_client.py
@@ -563,18 +563,6 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
         (table,), _ = mock_upload.await_args
         self.assertTrue(pa.types.is_string(table.schema.field("col").type))
 
-    async def test_upload_category_dataframe_converts_large_string_categories_via_schema(self) -> None:
-        """Test that upload_category_dataframe converts large_string categories (from pandas string[pyarrow]) to string via schema."""
-        dataframe = pd.DataFrame({"Category": pd.Categorical(pd.Series(["A", "B", "A", "C"], dtype="string[pyarrow]"))})
-        with mock.patch.object(self.data_client, "upload_category_table", new_callable=mock.AsyncMock) as mock_upload:
-            mock_upload.return_value = {}
-            await self.data_client.upload_category_dataframe(dataframe)
-
-        (table,), _ = mock_upload.await_args
-        col_type = table.schema.field("Category").type
-        self.assertTrue(pa.types.is_dictionary(col_type))
-        self.assertTrue(pa.types.is_string(col_type.value_type))
-
     async def test_download_table(self) -> None:
         """Test downloading tabular data using pyarrow."""
         get_object_response = load_test_data("get_object.json")

--- a/packages/evo-objects/tests/test_data_client.py
+++ b/packages/evo-objects/tests/test_data_client.py
@@ -405,15 +405,6 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
                 table_formats.INTEGER_ARRAY_1_INT32,
             ),
             (
-                "large_string",
-                pa.table({"Category": pa.array(["A", "B", "A", "C"], type=pa.large_string())}),
-                pa.table(
-                    {"key": pa.array([0, 1, 2], type=pa.int32()), "value": pa.array(["A", "B", "C"], type=pa.string())}
-                ),
-                pa.table({"Category": pa.array([0, 1, 0, 2], type=pa.int32())}),
-                table_formats.INTEGER_ARRAY_1_INT32,
-            ),
-            (
                 "multiple_columns",
                 pa.table(
                     {

--- a/packages/evo-objects/tests/test_data_client.py
+++ b/packages/evo-objects/tests/test_data_client.py
@@ -113,6 +113,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination") as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
+            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -262,6 +263,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination", autospec=True) as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
+            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -350,6 +352,7 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
             mock.patch("evo.objects.utils.table_formats.get_known_format") as mock_get_known_format,
             mock.patch("evo.common.io.upload.StorageDestination", autospec=True) as mock_destination,
             mock.patch("pyarrow.Table") as mock_pyarrow_table,
+            mock.patch("evo.objects.utils.data._cast_large_strings", side_effect=lambda t: t),
         ):
             mock_pyarrow_table.from_pandas.return_value = mock_table = mock.Mock()
             mock_get_known_format.return_value = mock_known_format = mock.Mock(spec=KnownTableFormat)
@@ -549,6 +552,32 @@ class TestObjectDataClient(TestWithConnector, TestWithStorage):
         self.assertEqual(category_info["table"]["table_format"], table_formats.LOOKUP_TABLE_INT32)
         self.assertEqual(category_info["values"]["table"], values_table)
         self.assertEqual(category_info["values"]["table_format"], values_table_format)
+
+    async def test_upload_dataframe_casts_large_string(self) -> None:
+        """Test that upload_dataframe casts large_string columns (from pandas string[pyarrow]) to string."""
+        dataframe = pd.DataFrame({"col": pd.Series(["A", "B", "C"], dtype="string[pyarrow]")})
+        with mock.patch.object(self.data_client, "upload_table", new_callable=mock.AsyncMock) as mock_upload:
+            mock_upload.return_value = {}
+            await self.data_client.upload_dataframe(dataframe)
+
+        (table,), _ = mock_upload.await_args
+        self.assertTrue(pa.types.is_string(table.schema.field("col").type))
+
+    async def test_upload_category_dataframe_casts_large_string_categories(self) -> None:
+        """Test that upload_category_dataframe casts large_string categories (from pandas string[pyarrow]) to string."""
+        dataframe = pd.DataFrame(
+            {"Category": pd.Categorical(pd.Series(["A", "B", "A", "C"], dtype="string[pyarrow]"))}
+        )
+        with mock.patch.object(
+            self.data_client, "upload_category_table", new_callable=mock.AsyncMock
+        ) as mock_upload:
+            mock_upload.return_value = {}
+            await self.data_client.upload_category_dataframe(dataframe)
+
+        (table,), _ = mock_upload.await_args
+        col_type = table.schema.field("Category").type
+        self.assertTrue(pa.types.is_dictionary(col_type))
+        self.assertTrue(pa.types.is_string(col_type.value_type))
 
     async def test_download_table(self) -> None:
         """Test downloading tabular data using pyarrow."""

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ test = [
 
 [[package]]
 name = "evo-objects"
-version = "0.4.0"
+version = "0.4.2"
 source = { editable = "packages/evo-objects" }
 dependencies = [
     { name = "evo-sdk-common", extra = ["jmespath"] },
@@ -1226,7 +1226,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.5.20"
+version = "0.5.21"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
## Description

Second attempt at getting rid of `large_string`.
- Reverted previous changes meant to fix this problem.
- Targeted functions that actually save dataframes to Parquet.

## Checklist

- [x] I have read the contributing guide and the code of conduct
