### PR TITLE
add support for simulation workflow task

### DIFF
--- a/mkdocs/site/packages/evo-compute/typed-objects/search/SearchNeighborhood.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/search/SearchNeighborhood.html
@@ -41,7 +41,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../source-target/AnySourceAttribute.html" class="nav-link">
+                                <a rel="next" href="../simulation/ConsimParameters.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/source-target/AnySourceAttribute.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/source-target/AnySourceAttribute.html
@@ -36,7 +36,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../search/SearchNeighborhood.html" class="nav-link">
+                                <a rel="prev" href="../simulation/ValidationSummary.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/docs/examples/simulation.ipynb
+++ b/packages/evo-compute/docs/examples/simulation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "df76aa52",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Conditional Simulation Compute Task\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5454a50",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Authentication\n",
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101afbc7",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76b5aed4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4acd7c99",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Example 1: Run Conditional Simulation on Existing Objects\n",
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e70000ea",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load the Source PointSet, Target Grid, and Variogram"
@@ -72,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcaa45bb",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "658bb008",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d7b48c2",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cc61e64",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe00d7d0",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3a6507b",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Optionally, Define the Distribution for Normal-Score Transformation\n",
@@ -147,11 +147,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2f0d063",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from evo.compute.tasks.simulation import Distribution, TailExtrapolation, UpperTail, LowerTail\n",
+    "from evo.compute.tasks.simulation import Distribution, LowerTail, TailExtrapolation, UpperTail\n",
     "\n",
     "# Define tail extrapolation based on data statistics\n",
     "# Upper tail max should be > data max\n",
@@ -170,14 +170,18 @@
     "    ),\n",
     ")\n",
     "\n",
-    "print(f\"Distribution configured:\")\n",
-    "print(f\"  Upper tail: power={distribution.tail_extrapolation.upper.power}, max={distribution.tail_extrapolation.upper.max}\")\n",
-    "print(f\"  Lower tail: power={distribution.tail_extrapolation.lower.power}, min={distribution.tail_extrapolation.lower.min}\")"
+    "print(\"Distribution configured:\")\n",
+    "print(\n",
+    "    f\"  Upper tail: power={distribution.tail_extrapolation.upper.power}, max={distribution.tail_extrapolation.upper.max}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"  Lower tail: power={distribution.tail_extrapolation.lower.power}, min={distribution.tail_extrapolation.lower.min}\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "83613592",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Run Conditional Simulation"
@@ -186,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c94249b",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffc48a18",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,22 +217,18 @@
     "    source=source_pointset.attributes[source_attr],\n",
     "    target_object=target_grid,\n",
     "    variogram=variogram,\n",
-    "    \n",
     "    # Search neighborhood\n",
     "    search=SearchNeighborhood(\n",
     "        ellipsoid=search_ellipsoid,\n",
     "        max_samples=20,\n",
     "    ),\n",
-    "    \n",
     "    # Distribution for normal-score transformation\n",
     "    distribution=distribution,\n",
-    "    \n",
     "    # Simulation settings\n",
-    "    number_of_simulations=100,        # Total realizations to generate\n",
+    "    number_of_simulations=100,  # Total realizations to generate\n",
     "    number_of_simulations_to_save=5,  # How many to save as attributes\n",
-    "    number_of_lines=500,              # Turning bands lines\n",
-    "    random_seed=12345,                # For reproducibility\n",
-    "    \n",
+    "    number_of_lines=500,  # Turning bands lines\n",
+    "    random_seed=12345,  # For reproducibility\n",
     "    # Output quantiles (e.g., P10, P50, P90)\n",
     "    location_wise_quantiles=[0.1, 0.5, 0.9],\n",
     ")\n",
@@ -244,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "214dbc0d",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
     "print(f\"Max attribute: {result.max_attribute.name}\")\n",
     "\n",
     "# List quantile attributes\n",
-    "print(f\"\\nQuantile attributes:\")\n",
+    "print(\"\\nQuantile attributes:\")\n",
     "for q in result.quantile_attributes:\n",
     "    print(f\"  P{int(q.quantile * 100)}: {q.name}\")"
    ]
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4339ac7c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d33d8168",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a17c17c5",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Example 2: Run Simulation with Validation\n",
@@ -307,15 +307,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f9c060c",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
     "from evo.compute.tasks.simulation import (\n",
     "    ConsimParameters,\n",
+    "    ReportMeanThresholds,\n",
     "    ValidationReportContext,\n",
     "    ValidationReportContextItem,\n",
-    "    ReportMeanThresholds,\n",
     ")\n",
     "\n",
     "# Create simulation parameters with validation\n",
@@ -324,22 +324,18 @@
     "    source=source_pointset.attributes[source_attr],\n",
     "    target_object=target_grid,\n",
     "    variogram=variogram,\n",
-    "    \n",
     "    # Search and distribution\n",
     "    search=SearchNeighborhood(\n",
     "        ellipsoid=search_ellipsoid,\n",
     "        max_samples=20,\n",
     "    ),\n",
     "    distribution=distribution,\n",
-    "    \n",
     "    # Simulation settings\n",
     "    number_of_simulations=100,\n",
     "    number_of_simulations_to_save=5,\n",
     "    location_wise_quantiles=[0.1, 0.25, 0.5, 0.75, 0.9],\n",
-    "    \n",
     "    # Enable validation\n",
     "    perform_validation=True,\n",
-    "    \n",
     "    # Validation report context\n",
     "    report_context=ValidationReportContext(\n",
     "        title=\"Grade Simulation Validation Report\",\n",
@@ -349,11 +345,10 @@
     "            ValidationReportContextItem(label=\"Method\", value=\"Turning Bands\"),\n",
     "        ],\n",
     "    ),\n",
-    "    \n",
     "    # User defined mean bias thresholds\n",
     "    report_mean_thresholds=ReportMeanThresholds(\n",
-    "        acceptable=5.0,   # <5% difference is acceptable\n",
-    "        marginal=10.0,    # 5-10% is marginal, >10% is unacceptable\n",
+    "        acceptable=5.0,  # <5% difference is acceptable\n",
+    "        marginal=10.0,  # 5-10% is marginal, >10% is unacceptable\n",
     "    ),\n",
     ")\n",
     "\n",
@@ -366,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d26bcb7",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +369,7 @@
     "if validated_result.validation_summary:\n",
     "    vs = validated_result.validation_summary\n",
     "    pct_diff = abs(vs.mean - vs.reference_mean) / vs.reference_mean * 100\n",
-    "    print(f\"Validation Summary:\")\n",
+    "    print(\"Validation Summary:\")\n",
     "    print(f\"  Reference mean (input):  {vs.reference_mean:.4f}\")\n",
     "    print(f\"  Simulated mean:          {vs.mean:.4f}\")\n",
     "    print(f\"  Difference:              {pct_diff:.2f}%\")\n",
@@ -393,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "876b33dc",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Example 3: Create Objects and Run Simulation\n",
@@ -403,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3edebd4",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Create the Source PointSet"
@@ -412,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "927380b3",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +441,7 @@
     "source_pointset_created = await PointSet.create(manager, pointset_data)\n",
     "\n",
     "print(f\"Created source pointset: {source_pointset_created.name}\")\n",
-    "print(f\"Grade statistics:\")\n",
+    "print(\"Grade statistics:\")\n",
     "print(f\"  Min:  {grade.min():.4f}\")\n",
     "print(f\"  Max:  {grade.max():.4f}\")\n",
     "print(f\"  Mean: {grade.mean():.4f}\")"
@@ -455,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27e9e785",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b22012d5",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Create a Variogram"
@@ -474,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4973ba58",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d2e2e60",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28d14b4b",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Create the Target Grid"
@@ -544,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b48c54fe",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +548,7 @@
     "\n",
     "# Define grid dimensions\n",
     "nx, ny, nz = 20, 20, 10  # Number of cells in each direction\n",
-    "cell_size = 50.0        # Size of each cell\n",
+    "cell_size = 50.0  # Size of each cell\n",
     "\n",
     "# Create a mask for the grid (all cells active)\n",
     "total_cells = nx * ny * nz\n",
@@ -580,7 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00f73e36",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "592ceb6d",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Run Conditional Simulation on Created Objects"
@@ -599,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5a1861e",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,9 +602,9 @@
     "from evo.compute.tasks.simulation import (\n",
     "    ConsimParameters,\n",
     "    Distribution,\n",
+    "    LowerTail,\n",
     "    TailExtrapolation,\n",
     "    UpperTail,\n",
-    "    LowerTail,\n",
     ")\n",
     "\n",
     "# Get ellipsoid from the variogram (longest range structure)\n",
@@ -650,7 +645,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3c15559",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -663,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187f38ef",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/packages/evo-compute/docs/examples/simulation.ipynb
+++ b/packages/evo-compute/docs/examples/simulation.ipynb
@@ -1,0 +1,697 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "df76aa52",
+   "metadata": {},
+   "source": [
+    "# Conditional Simulation Compute Task\n",
+    "\n",
+    "This notebook demonstrates how to run conditional simulation (consim) compute tasks using the `evo-compute` package.\n",
+    "\n",
+    "Conditional simulation is a geostatistical technique that generates multiple equally probable realizations\n",
+    "of a spatial variable, honoring both the conditioning data and the spatial correlation model (variogram).\n",
+    "Unlike kriging which produces a single \"best estimate\", simulation captures the full range of uncertainty."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5454a50",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "First, authenticate using the `ServiceManagerWidget`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "101afbc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.notebooks import ServiceManagerWidget\n",
+    "\n",
+    "# Use integration environment\n",
+    "manager = await ServiceManagerWidget.with_auth_code(\n",
+    "    client_id=\"<my-client-id>\",\n",
+    "    cache_location=\"./notebook-data\",\n",
+    ").login()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76b5aed4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the widgets extension for rich HTML display\n",
+    "%load_ext evo.widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4acd7c99",
+   "metadata": {},
+   "source": [
+    "## Example 1: Run Conditional Simulation on Existing Objects\n",
+    "\n",
+    "This example shows how to run conditional simulation using existing geoscience objects (source pointset, target grid, and variogram)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e70000ea",
+   "metadata": {},
+   "source": [
+    "### Load the Source PointSet, Target Grid, and Variogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcaa45bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.objects.typed import object_from_path\n",
+    "\n",
+    "# Load objects by path\n",
+    "source_pointset = await object_from_path(manager, \"source_pointset.json\")\n",
+    "target_grid = await object_from_path(manager, \"target_grid.json\")\n",
+    "variogram = await object_from_path(manager, \"variogram.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "658bb008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pretty-print the source pointset (includes Portal/Viewer links)\n",
+    "source_pointset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d7b48c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# View the source pointset attributes\n",
+    "source_pointset.attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cc61e64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe00d7d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get source data statistics for distribution setup\n",
+    "source_df = await source_pointset.to_dataframe()\n",
+    "source_attr = \"Ag_ppm Values\"  # Replace with your attribute name\n",
+    "\n",
+    "print(f\"Source attribute: {source_attr}\")\n",
+    "print(f\"  Min:  {source_df[source_attr].min():.4f}\")\n",
+    "print(f\"  Max:  {source_df[source_attr].max():.4f}\")\n",
+    "print(f\"  Mean: {source_df[source_attr].mean():.4f}\")\n",
+    "print(f\"  Std:  {source_df[source_attr].std():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a6507b",
+   "metadata": {},
+   "source": [
+    "### Optionally, Define the Distribution for Normal-Score Transformation\n",
+    "\n",
+    "Conditional simulation requires transforming data to normal-score space, if not specified by the user it will be constructed by deault. Explicitly creating the distrubtion provides more control over tail extrapolation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2f0d063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.compute.tasks.simulation import Distribution, TailExtrapolation, UpperTail, LowerTail\n",
+    "\n",
+    "# Define tail extrapolation based on data statistics\n",
+    "# Upper tail max should be > data max\n",
+    "# Lower tail min should be < data min (or 0 for grades that can't be negative)\n",
+    "\n",
+    "distribution = Distribution(\n",
+    "    tail_extrapolation=TailExtrapolation(\n",
+    "        upper=UpperTail(\n",
+    "            power=0.5,  # Controls tail shape (0.5 = linear extrapolation)\n",
+    "            max=source_df[source_attr].max() * 1.5,  # 50% beyond max\n",
+    "        ),\n",
+    "        lower=LowerTail(\n",
+    "            power=0.5,\n",
+    "            min=0.0,  # Grades can't be negative\n",
+    "        ),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"Distribution configured:\")\n",
+    "print(f\"  Upper tail: power={distribution.tail_extrapolation.upper.power}, max={distribution.tail_extrapolation.upper.max}\")\n",
+    "print(f\"  Lower tail: power={distribution.tail_extrapolation.lower.power}, min={distribution.tail_extrapolation.lower.min}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83613592",
+   "metadata": {},
+   "source": [
+    "### Run Conditional Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c94249b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.compute.tasks import SearchNeighborhood, run\n",
+    "from evo.compute.tasks.simulation import ConsimParameters\n",
+    "\n",
+    "# Get ellipsoid from the variogram structure with largest range (default)\n",
+    "var_ell = variogram.get_ellipsoid()\n",
+    "\n",
+    "# Create search ellipsoid by scaling the variogram ellipsoid by 2x\n",
+    "search_ellipsoid = var_ell.scaled(2.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffc48a18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create simulation parameters\n",
+    "consim_params = ConsimParameters(\n",
+    "    # Source and target\n",
+    "    source=source_pointset.attributes[source_attr],\n",
+    "    target_object=target_grid,\n",
+    "    variogram=variogram,\n",
+    "    \n",
+    "    # Search neighborhood\n",
+    "    search=SearchNeighborhood(\n",
+    "        ellipsoid=search_ellipsoid,\n",
+    "        max_samples=20,\n",
+    "    ),\n",
+    "    \n",
+    "    # Distribution for normal-score transformation\n",
+    "    distribution=distribution,\n",
+    "    \n",
+    "    # Simulation settings\n",
+    "    number_of_simulations=100,        # Total realizations to generate\n",
+    "    number_of_simulations_to_save=5,  # How many to save as attributes\n",
+    "    number_of_lines=500,              # Turning bands lines\n",
+    "    random_seed=12345,                # For reproducibility\n",
+    "    \n",
+    "    # Output quantiles (e.g., P10, P50, P90)\n",
+    "    location_wise_quantiles=[0.1, 0.5, 0.9],\n",
+    ")\n",
+    "\n",
+    "# Run the simulation task (progress feedback is shown by default)\n",
+    "print(\"Submitting conditional simulation task...\")\n",
+    "result = await run(manager, consim_params, preview=True)\n",
+    "\n",
+    "# Display the result summary\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "214dbc0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access summary statistics\n",
+    "print(f\"Mean attribute: {result.mean_attribute.name}\")\n",
+    "print(f\"Variance attribute: {result.variance_attribute.name}\")\n",
+    "print(f\"Min attribute: {result.min_attribute.name}\")\n",
+    "print(f\"Max attribute: {result.max_attribute.name}\")\n",
+    "\n",
+    "# List quantile attributes\n",
+    "print(f\"\\nQuantile attributes:\")\n",
+    "for q in result.quantile_attributes:\n",
+    "    print(f\"  P{int(q.quantile * 100)}: {q.name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4339ac7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the simulation results as a DataFrame\n",
+    "df = await result.to_dataframe()\n",
+    "print(f\"Retrieved {len(df)} cells with simulation results\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d33d8168",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize uncertainty (P90 - P10 spread)\n",
+    "import plotly.express as px\n",
+    "\n",
+    "# Find quantile column names\n",
+    "p10_col = [q.name for q in result.quantile_attributes if q.quantile == 0.1][0]\n",
+    "p50_col = [q.name for q in result.quantile_attributes if q.quantile == 0.5][0]\n",
+    "p90_col = [q.name for q in result.quantile_attributes if q.quantile == 0.9][0]\n",
+    "\n",
+    "df[\"uncertainty\"] = df[p90_col] - df[p10_col]\n",
+    "\n",
+    "fig = px.histogram(df, x=\"uncertainty\", nbins=50, title=\"Uncertainty Distribution (P90 - P10)\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a17c17c5",
+   "metadata": {},
+   "source": [
+    "## Example 2: Run Simulation with Validation\n",
+    "\n",
+    "This example demonstrates how to run conditional simulation with validation enabled, which generates a validation report and provides a link to the validation dashboard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f9c060c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.compute.tasks.simulation import (\n",
+    "    ConsimParameters,\n",
+    "    ValidationReportContext,\n",
+    "    ValidationReportContextItem,\n",
+    "    ReportMeanThresholds,\n",
+    ")\n",
+    "\n",
+    "# Create simulation parameters with validation\n",
+    "consim_params_validated = ConsimParameters(\n",
+    "    # Same source/target/variogram as before\n",
+    "    source=source_pointset.attributes[source_attr],\n",
+    "    target_object=target_grid,\n",
+    "    variogram=variogram,\n",
+    "    \n",
+    "    # Search and distribution\n",
+    "    search=SearchNeighborhood(\n",
+    "        ellipsoid=search_ellipsoid,\n",
+    "        max_samples=20,\n",
+    "    ),\n",
+    "    distribution=distribution,\n",
+    "    \n",
+    "    # Simulation settings\n",
+    "    number_of_simulations=100,\n",
+    "    number_of_simulations_to_save=5,\n",
+    "    location_wise_quantiles=[0.1, 0.25, 0.5, 0.75, 0.9],\n",
+    "    \n",
+    "    # Enable validation\n",
+    "    perform_validation=True,\n",
+    "    \n",
+    "    # Validation report context\n",
+    "    report_context=ValidationReportContext(\n",
+    "        title=\"Grade Simulation Validation Report\",\n",
+    "        details=[\n",
+    "            ValidationReportContextItem(label=\"Domain\", value=\"All\"),\n",
+    "            ValidationReportContextItem(label=\"Variable\", value=source_attr),\n",
+    "            ValidationReportContextItem(label=\"Method\", value=\"Turning Bands\"),\n",
+    "        ],\n",
+    "    ),\n",
+    "    \n",
+    "    # User defined mean bias thresholds\n",
+    "    report_mean_thresholds=ReportMeanThresholds(\n",
+    "        acceptable=5.0,   # <5% difference is acceptable\n",
+    "        marginal=10.0,    # 5-10% is marginal, >10% is unacceptable\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(\"Submitting simulation with validation...\")\n",
+    "validated_result = await run(manager, consim_params_validated, preview=True)\n",
+    "\n",
+    "print(validated_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d26bcb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check validation summary\n",
+    "if validated_result.validation_summary:\n",
+    "    vs = validated_result.validation_summary\n",
+    "    pct_diff = abs(vs.mean - vs.reference_mean) / vs.reference_mean * 100\n",
+    "    print(f\"Validation Summary:\")\n",
+    "    print(f\"  Reference mean (input):  {vs.reference_mean:.4f}\")\n",
+    "    print(f\"  Simulated mean:          {vs.mean:.4f}\")\n",
+    "    print(f\"  Difference:              {pct_diff:.2f}%\")\n",
+    "else:\n",
+    "    print(\"No validation summary available\")\n",
+    "\n",
+    "# Check for validation report link\n",
+    "if validated_result.validation_report:\n",
+    "    print(f\"\\nValidation report: {validated_result.validation_report.name}\")\n",
+    "    print(f\"  Reference: {validated_result.validation_report.reference}\")\n",
+    "\n",
+    "# Check for dashboard link\n",
+    "if validated_result.dashboard_link:\n",
+    "    print(f\"\\nDashboard: {validated_result.dashboard_link}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "876b33dc",
+   "metadata": {},
+   "source": [
+    "## Example 3: Create Objects and Run Simulation\n",
+    "\n",
+    "This example shows how to create the input objects from scratch and then run conditional simulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3edebd4",
+   "metadata": {},
+   "source": [
+    "### Create the Source PointSet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "927380b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from evo.objects.typed import EpsgCode, PointSet, PointSetData\n",
+    "\n",
+    "# Generate sample point data with realistic grade distribution\n",
+    "n_points = 500\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "# Create points in a 1000x1000x200 domain\n",
+    "x = np.random.uniform(0, 1000, n_points)\n",
+    "y = np.random.uniform(0, 1000, n_points)\n",
+    "z = np.random.uniform(0, 200, n_points)\n",
+    "\n",
+    "# Create a grade attribute with lognormal distribution (common for mineral grades)\n",
+    "grade = np.random.lognormal(mean=0.5, sigma=0.8, size=n_points)\n",
+    "grade = np.clip(grade, 0.01, 20)  # Clip to realistic range\n",
+    "\n",
+    "# Create pointset using PointSetData\n",
+    "pointset_data = PointSetData(\n",
+    "    name=f\"Simulation Source Points - {uuid.uuid4()}\",\n",
+    "    coordinate_reference_system=EpsgCode(32632),\n",
+    "    locations=pd.DataFrame({\"x\": x, \"y\": y, \"z\": z, \"grade\": grade}),\n",
+    ")\n",
+    "\n",
+    "# Create the pointset object\n",
+    "source_pointset_created = await PointSet.create(manager, pointset_data)\n",
+    "\n",
+    "print(f\"Created source pointset: {source_pointset_created.name}\")\n",
+    "print(f\"Grade statistics:\")\n",
+    "print(f\"  Min:  {grade.min():.4f}\")\n",
+    "print(f\"  Max:  {grade.max():.4f}\")\n",
+    "print(f\"  Mean: {grade.mean():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e9e785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pretty-print the created pointset\n",
+    "source_pointset_created"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b22012d5",
+   "metadata": {},
+   "source": [
+    "### Create a Variogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4973ba58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.objects.typed import (\n",
+    "    Ellipsoid,\n",
+    "    EllipsoidRanges,\n",
+    "    Rotation,\n",
+    "    SphericalStructure,\n",
+    "    Variogram,\n",
+    "    VariogramData,\n",
+    ")\n",
+    "\n",
+    "# Define a nested spherical variogram model\n",
+    "variogram_data = VariogramData(\n",
+    "    name=f\"Simulation Variogram - {uuid.uuid4()}\",\n",
+    "    sill=1.0,\n",
+    "    nugget=0.1,\n",
+    "    is_rotation_fixed=True,\n",
+    "    modelling_space=\"data\",\n",
+    "    data_variance=1.0,\n",
+    "    structures=[\n",
+    "        # Short-range structure\n",
+    "        SphericalStructure(\n",
+    "            contribution=0.4,\n",
+    "            anisotropy=Ellipsoid(\n",
+    "                ranges=EllipsoidRanges(major=100.0, semi_major=80.0, minor=50.0),\n",
+    "                rotation=Rotation(dip_azimuth=45.0, dip=0.0, pitch=0.0),\n",
+    "            ),\n",
+    "        ),\n",
+    "        # Long-range structure\n",
+    "        SphericalStructure(\n",
+    "            contribution=0.5,\n",
+    "            anisotropy=Ellipsoid(\n",
+    "                ranges=EllipsoidRanges(major=300.0, semi_major=200.0, minor=100.0),\n",
+    "                rotation=Rotation(dip_azimuth=45.0, dip=0.0, pitch=0.0),\n",
+    "            ),\n",
+    "        ),\n",
+    "    ],\n",
+    "    attribute=\"grade\",\n",
+    "    domain=\"all\",\n",
+    ")\n",
+    "\n",
+    "variogram_created = await Variogram.create(manager, variogram_data)\n",
+    "\n",
+    "print(f\"Created variogram: {variogram_created.name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d2e2e60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pretty-print the created variogram\n",
+    "variogram_created"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28d14b4b",
+   "metadata": {},
+   "source": [
+    "### Create the Target Grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b48c54fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.objects.typed import Point3, RegularMasked3DGrid, RegularMasked3DGridData, Size3d, Size3i\n",
+    "from evo.objects.typed import Rotation as GridRotation\n",
+    "\n",
+    "# Define grid dimensions\n",
+    "nx, ny, nz = 20, 20, 10  # Number of cells in each direction\n",
+    "cell_size = 50.0        # Size of each cell\n",
+    "\n",
+    "# Create a mask for the grid (all cells active)\n",
+    "total_cells = nx * ny * nz\n",
+    "mask = np.ones(total_cells, dtype=bool)\n",
+    "\n",
+    "# Create masked grid\n",
+    "grid_data = RegularMasked3DGridData(\n",
+    "    name=f\"Simulation Target Grid - {uuid.uuid4()}\",\n",
+    "    coordinate_reference_system=EpsgCode(32632),\n",
+    "    origin=Point3(0, 0, 0),\n",
+    "    size=Size3i(nx, ny, nz),\n",
+    "    cell_size=Size3d(cell_size, cell_size, cell_size / 2),  # Smaller vertical cells\n",
+    "    rotation=GridRotation(0, 0, 0),\n",
+    "    mask=mask,\n",
+    "    cell_data=None,\n",
+    ")\n",
+    "\n",
+    "target_grid_created = await RegularMasked3DGrid.create(manager, grid_data)\n",
+    "\n",
+    "print(f\"Created target grid: {target_grid_created.name}\")\n",
+    "print(f\"  Total cells: {nx} x {ny} x {nz} = {total_cells}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f73e36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pretty-print the created grid\n",
+    "target_grid_created"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "592ceb6d",
+   "metadata": {},
+   "source": [
+    "### Run Conditional Simulation on Created Objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5a1861e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.compute.tasks import SearchNeighborhood, run\n",
+    "from evo.compute.tasks.simulation import (\n",
+    "    ConsimParameters,\n",
+    "    Distribution,\n",
+    "    TailExtrapolation,\n",
+    "    UpperTail,\n",
+    "    LowerTail,\n",
+    ")\n",
+    "\n",
+    "# Get ellipsoid from the variogram (longest range structure)\n",
+    "var_ell = variogram_created.get_ellipsoid()\n",
+    "search_ellipsoid = var_ell.scaled(2.0)\n",
+    "\n",
+    "# Define distribution based on data\n",
+    "distribution_created = Distribution(\n",
+    "    tail_extrapolation=TailExtrapolation(\n",
+    "        upper=UpperTail(power=0.5, max=grade.max() * 1.5),\n",
+    "        lower=LowerTail(power=0.5, min=0.0),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# Create simulation parameters\n",
+    "consim_params_created = ConsimParameters(\n",
+    "    source=source_pointset_created.locations.attributes[\"grade\"],\n",
+    "    target_object=target_grid_created,\n",
+    "    variogram=variogram_created,\n",
+    "    search=SearchNeighborhood(\n",
+    "        ellipsoid=search_ellipsoid,\n",
+    "        max_samples=30,\n",
+    "    ),\n",
+    "    distribution=distribution_created,\n",
+    "    number_of_simulations=50,\n",
+    "    number_of_simulations_to_save=3,\n",
+    "    location_wise_quantiles=[0.1, 0.5, 0.9],\n",
+    "    random_seed=42,\n",
+    ")\n",
+    "\n",
+    "print(\"Submitting conditional simulation task...\")\n",
+    "result_created = await run(manager, consim_params_created, preview=True)\n",
+    "\n",
+    "print(\"Task completed!\")\n",
+    "print(result_created)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c15559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the simulation results as a DataFrame\n",
+    "df_created = await result_created.to_dataframe()\n",
+    "print(f\"Retrieved {len(df_created)} cells with simulation results\")\n",
+    "df_created.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "187f38ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the target object for further analysis\n",
+    "target_with_results = await result_created.get_target_object()\n",
+    "target_with_results"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "evo-sdk (3.10.18)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -71,12 +71,12 @@ from .simulation import (
     ConsimResult,
     Distribution,
     LossCalculation,
+    LowerTail,
     MaterialCategory,
+    ReportMeanThresholds,
     TailExtrapolation,
     UpperTail,
-    LowerTail,
     ValidationReportContext,
-    ReportMeanThresholds,
 )
 
 
@@ -171,16 +171,25 @@ async def run(
 
 __all__ = [
     "BlockDiscretisation",
+    "ConsimResult",
     "CreateAttribute",
+    "Distribution",
     "Ellipsoid",
     "EllipsoidRanges",
     "KrigingResult",
+    "LossCalculation",
+    "LowerTail",
+    "MaterialCategory",
     "RegionFilter",
+    "ReportMeanThresholds",
     "Rotation",
     "SearchNeighborhood",
     "Source",
+    "TailExtrapolation",
     "Target",
     "TaskResultList",
     "UpdateAttribute",
+    "UpperTail",
+    "ValidationReportContext",
     "run",
 ]

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,9 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import simulation as _simulation_module  # noqa: F401
 
 # Shared components from common module
 from .common import (
@@ -63,6 +64,19 @@ from .kriging import (
     BlockDiscretisation,
     KrigingResult,
     RegionFilter,
+)
+
+# Simulation-specific result types
+from .simulation import (
+    ConsimResult,
+    Distribution,
+    LossCalculation,
+    MaterialCategory,
+    TailExtrapolation,
+    UpperTail,
+    LowerTail,
+    ValidationReportContext,
+    ReportMeanThresholds,
 )
 
 

--- a/packages/evo-compute/src/evo/compute/tasks/simulation.py
+++ b/packages/evo-compute/src/evo/compute/tasks/simulation.py
@@ -396,9 +396,6 @@ class ConsimParameters(BaseModel):
         return result
 
 
-
-
-
 # =============================================================================
 # Consim Result Types
 # =============================================================================
@@ -668,7 +665,9 @@ class ConsimResult:
         if self.simulations_attribute:
             lines.append(f"  Simulations: {self.simulations_attribute.name}")
         if self.validation_summary:
-            lines.append(f"  Validation: ref_mean={self.validation_summary.reference_mean:.4f}, sim_mean={self.validation_summary.mean:.4f}")
+            lines.append(
+                f"  Validation: ref_mean={self.validation_summary.reference_mean:.4f}, sim_mean={self.validation_summary.mean:.4f}"
+            )
         if self.dashboard_link:
             lines.append(f"  Dashboard: {self.dashboard_link}")
         return "\n".join(lines)

--- a/packages/evo-compute/src/evo/compute/tasks/simulation.py
+++ b/packages/evo-compute/src/evo/compute/tasks/simulation.py
@@ -1,0 +1,695 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Conditional simulation compute task client.
+
+This module provides typed dataclass models and convenience functions for running
+the conditional simulation task (geostatistics/consim).
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
+    >>> from evo.compute.tasks.simulation import ConsimParameters, Distribution
+    >>>
+    >>> params = ConsimParameters(
+    ...     source=pointset.attributes["grade"],
+    ...     target_object=grid,
+    ...     variogram=variogram,
+    ...     search=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=20,
+    ...     ),
+    ...     distribution=Distribution(
+    ...         tail_extrapolation=TailExtrapolation(
+    ...             upper=UpperTail(power=0.5, max=10.0),
+    ...         ),
+    ...     ),
+    ...     number_of_simulations=100,
+    ... )
+    >>> result = await run(manager, params, preview=True)
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+
+# Import shared components
+from .common import (
+    AnySourceAttribute,
+    CreateAttribute,
+    GeoscienceObjectReference,
+    SearchNeighborhood,
+    UpdateAttribute,
+)
+from .common.results import TaskAttribute
+from .common.runner import TaskRunner
+
+# Import BlockDiscretisation from kriging to reuse
+# This avoids duplication while keeping the type available
+from .kriging import BlockDiscretisation
+
+__all__ = [
+    # Simulation-specific exports
+    "ConsimParameters",
+    "ConsimResult",
+    "ConsimResultModel",
+    "ConsimRunner",
+    "ConsimTarget",
+    "Distribution",
+    "LossCalculation",
+    "LowerTail",
+    "MaterialCategory",
+    "QuantileAttribute",
+    "ReportMeanThresholds",
+    "SummaryAttributes",
+    "TailExtrapolation",
+    "UpperTail",
+    "ValidationReportContext",
+    "ValidationReportContextItem",
+    "ValidationSummary",
+]
+
+
+# =============================================================================
+# Distribution Types
+# =============================================================================
+
+
+class UpperTail(BaseModel):
+    """Power model for extrapolating the upper tail of the distribution.
+
+    Example:
+        >>> upper = UpperTail(power=0.5, max=10.0)
+    """
+
+    power: float = Field(gt=0, le=1)
+    """Denominator of the exponent for the power model (between 0 exclusive and 1 inclusive)."""
+
+    max: float
+    """Maximum extent of tail, must be greater than the maximum value in the data."""
+
+
+class LowerTail(BaseModel):
+    """Power model for extrapolating the lower tail of the distribution.
+
+    Example:
+        >>> lower = LowerTail(power=0.5, min=0.0)
+    """
+
+    power: float = Field(gt=0, le=1)
+    """Denominator of the exponent for the power model (between 0 exclusive and 1 inclusive)."""
+
+    min: float
+    """Minimum extent of tail, must be less than the minimum value in the data."""
+
+
+class TailExtrapolation(BaseModel):
+    """Tail extrapolation configuration for the distribution.
+
+    Example:
+        >>> extrapolation = TailExtrapolation(
+        ...     upper=UpperTail(power=0.5, max=10.0),
+        ...     lower=LowerTail(power=0.5, min=0.0),
+        ... )
+    """
+
+    upper: UpperTail
+    """Power model for extrapolating the upper tail of the distribution."""
+
+    lower: LowerTail | None = None
+    """Power model for extrapolating the lower tail of the distribution. Optional."""
+
+
+class Distribution(BaseModel):
+    """Parameters for a continuous distribution used for normal-score transformation.
+
+    Example:
+        >>> dist = Distribution(
+        ...     tail_extrapolation=TailExtrapolation(
+        ...         upper=UpperTail(power=0.5, max=10.0),
+        ...     ),
+        ...     weights="weight_attribute",
+        ... )
+    """
+
+    tail_extrapolation: TailExtrapolation
+    """Tail extrapolation configuration."""
+
+    weights: str | None = None
+    """Optional weights attribute for weighted distribution."""
+
+
+# =============================================================================
+# Loss Calculation Types
+# =============================================================================
+
+
+class MaterialCategory(BaseModel):
+    """Material category for loss calculations.
+
+    Ordered list of material categories, from lowest to highest cutoff grade.
+
+    Example:
+        >>> category = MaterialCategory(
+        ...     label="Ore",
+        ...     cutoff_grade=0.5,
+        ...     metal_price=1000.0,
+        ...     processing_cost=10.0,
+        ...     mining_waste_cost=2.0,
+        ...     mining_ore_cost=5.0,
+        ...     metal_recovery_fraction=0.9,
+        ... )
+    """
+
+    cutoff_grade: float | None = None
+    """Cutoff grade for the category."""
+
+    metal_price: float | None = None
+    """Price of the metal per unit."""
+
+    label: str | None = None
+    """Label for the material category."""
+
+    processing_cost: float
+    """Processing cost per unit of material."""
+
+    mining_waste_cost: float
+    """Mining cost per unit of waste material."""
+
+    mining_ore_cost: float
+    """Mining cost per unit of ore material."""
+
+    metal_recovery_fraction: float
+    """Fraction of metal expected to be recovered during processing."""
+
+
+class LossCalculation(BaseModel):
+    """Settings for loss calculations.
+
+    Example:
+        >>> loss = LossCalculation(
+        ...     material_categories=[
+        ...         MaterialCategory(
+        ...             label="Waste",
+        ...             processing_cost=0.0,
+        ...             mining_waste_cost=2.0,
+        ...             mining_ore_cost=0.0,
+        ...             metal_recovery_fraction=0.0,
+        ...         ),
+        ...         MaterialCategory(
+        ...             label="Ore",
+        ...             cutoff_grade=0.5,
+        ...             metal_price=1000.0,
+        ...             processing_cost=10.0,
+        ...             mining_waste_cost=0.0,
+        ...             mining_ore_cost=5.0,
+        ...             metal_recovery_fraction=0.9,
+        ...         ),
+        ...     ],
+        ...     target_attribute=CreateAttribute(name="loss_results"),
+        ... )
+    """
+
+    material_categories: list[MaterialCategory]
+    """Ordered list of material categories, from lowest to highest cutoff grade."""
+
+    target_attribute: CreateAttribute | UpdateAttribute
+    """The target attribute that will be created or updated with loss calculation results."""
+
+
+# =============================================================================
+# Validation Report Types
+# =============================================================================
+
+
+class ValidationReportContextItem(BaseModel):
+    """Key-value pair for validation report context."""
+
+    label: str
+    """Label of the context item, which will appear on the report."""
+
+    value: str
+    """Value of the context item."""
+
+
+class ValidationReportContext(BaseModel):
+    """Context for the validation report.
+
+    Example:
+        >>> context = ValidationReportContext(
+        ...     title="Copper Grade Simulation Validation",
+        ...     details=[
+        ...         ValidationReportContextItem(label="Domain", value="LMS1"),
+        ...         ValidationReportContextItem(label="Variable", value="CU_pct"),
+        ...     ],
+        ... )
+    """
+
+    title: str
+    """Title that will appear on the report."""
+
+    details: list[ValidationReportContextItem]
+    """Key-value pairs of details to appear on the report."""
+
+
+class ReportMeanThresholds(BaseModel):
+    """Thresholds for the mean comparison in the validation report.
+
+    Example:
+        >>> thresholds = ReportMeanThresholds(acceptable=5.0, marginal=10.0)
+    """
+
+    acceptable: float
+    """Threshold for the percentage difference between the reference and simulated means that is considered acceptable."""
+
+    marginal: float
+    """Threshold for the percentage difference between the reference and simulated means that is considered marginal."""
+
+
+# =============================================================================
+# Consim Parameters
+# =============================================================================
+
+
+class ConsimParameters(BaseModel):
+    """Parameters for the conditional simulation task.
+
+    Defines all inputs needed to run a conditional simulation (turning bands) task.
+
+    Example:
+        >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
+        >>> from evo.compute.tasks.simulation import ConsimParameters, Distribution, TailExtrapolation, UpperTail
+        >>>
+        >>> params = ConsimParameters(
+        ...     source=pointset.attributes["grade"],  # Source attribute
+        ...     target_object=grid,  # Target grid object
+        ...     variogram=variogram,  # Variogram model
+        ...     search=SearchNeighborhood(
+        ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+        ...         max_samples=20,
+        ...     ),
+        ...     distribution=Distribution(
+        ...         tail_extrapolation=TailExtrapolation(
+        ...             upper=UpperTail(power=0.5, max=10.0),
+        ...         ),
+        ...     ),
+        ...     number_of_simulations=100,
+        ...     location_wise_quantiles=[0.1, 0.5, 0.9],
+        ... )
+        >>>
+        >>> result = await run(manager, params, preview=True)
+    """
+
+    model_config = {"populate_by_name": True}
+
+    # Source specification
+    source: AnySourceAttribute
+    """The source object and attribute containing known values for conditioning."""
+
+    # Target specification
+    target_object: GeoscienceObjectReference
+    """Reference to the target grid object. New attributes will be created on this object.
+    Supported schemas: regular-3d-grid, regular-masked-3d-grid."""
+
+    # Variogram
+    variogram: GeoscienceObjectReference = Field(alias="variogram_model")
+    """Reference to the variogram model used to model the covariance within the domain.
+    Supported schemas: variogram/[>=1.1,<2]."""
+
+    # Search neighborhood
+    search: SearchNeighborhood = Field(alias="neighborhood")
+    """Search neighborhood for conditioning."""
+
+    # Distribution (required for normal-score transformation)
+    distribution: Distribution | None = None
+    """Parameters for the continuous distribution used for normal-score transformation."""
+
+    # Kriging method for conditioning
+    kriging_method: Literal["simple", "ordinary"] = "simple"
+    """The kriging method to use for the conditioning step. Defaults to 'simple'."""
+
+    # Block discretization (required by API)
+    block_discretisation: "BlockDiscretisation" = Field(
+        default_factory=lambda: BlockDiscretisation(nx=3, ny=3, nz=3),
+        alias="block_discretization",
+    )
+    """Sub-block discretization used for support correction within each grid block.
+    Defaults to BlockDiscretisation(nx=3, ny=3, nz=3) for block kriging."""
+
+    # Simulation parameters
+    number_of_lines: int = 500
+    """Number of lines to use for the turning-band simulation. Defaults to 500."""
+
+    number_of_simulations: int = 1
+    """Number of simulations to run. Defaults to 1."""
+
+    random_seed: int = 38239342
+    """Random seed for simulation and tie-breaking. Defaults to 38239342."""
+
+    number_of_simulations_to_save: int = 5
+    """Number of simulations to publish to the output object.
+    If perform_validation is true, the minimum value must be at least 1. Defaults to 5."""
+
+    # Output options
+    location_wise_quantiles: list[float] | None = None
+    """List of quantiles to compute for each location (e.g., [0.1, 0.5, 0.9])."""
+
+    # Validation
+    perform_validation: bool = False
+    """Whether to run validation and generate a validation report. Defaults to False."""
+
+    report_context: ValidationReportContext | None = None
+    """Context for the validation report."""
+
+    report_mean_thresholds: ReportMeanThresholds | None = None
+    """Thresholds for the mean comparison in the validation report."""
+
+    # Loss calculation
+    loss_calculation: LossCalculation | None = None
+    """Settings for loss calculations. Optional."""
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        result = handler(self)
+
+        # The API expects source_object and source_attribute as separate fields
+        # Convert from our unified source representation
+        if "source" in result:
+            source = result.pop("source")
+            result["source_object"] = source["object"]
+            result["source_attribute"] = source["attribute"]
+
+        return result
+
+
+
+
+
+# =============================================================================
+# Consim Result Types
+# =============================================================================
+
+
+class SummaryAttributes(BaseModel):
+    """Summary statistics attributes from simulation results."""
+
+    mean: TaskAttribute
+    """Attribute containing the mean of the simulations."""
+
+    variance: TaskAttribute
+    """Attribute containing the variance of the simulations."""
+
+    min: TaskAttribute
+    """Attribute containing the minimum of the simulations."""
+
+    max: TaskAttribute
+    """Attribute containing the maximum of the simulations."""
+
+
+class QuantileAttribute(BaseModel):
+    """Quantile attribute from simulation results."""
+
+    reference: str
+    """Reference to the attribute in the geoscience object."""
+
+    name: str
+    """The name of the output attribute."""
+
+    quantile: float
+    """Quantile of the simulations that this attribute represents."""
+
+
+class ValidationSummary(BaseModel):
+    """Summary of validation results."""
+
+    reference_mean: float
+    """Mean of the input values."""
+
+    mean: float
+    """Mean of the simulated values."""
+
+
+class FileReference(BaseModel):
+    """Reference to a file."""
+
+    reference: str
+    """Reference to the file."""
+
+    name: str
+    """The name of the file, typically the terminal segment of the path."""
+
+
+class ConsimLinks(BaseModel):
+    """Links related to the simulation task."""
+
+    dashboard: str | None = None
+    """Link to the validation dashboard."""
+
+
+class ConsimTarget(BaseModel):
+    """Target information from a conditional simulation result.
+
+    Contains references to all output attributes created by the simulation.
+    """
+
+    reference: str
+    """Reference to the target geoscience object."""
+
+    name: str
+    """The name of the geoscience object."""
+
+    description: str | None = None
+    """The description of the geoscience object."""
+
+    schema_id: str
+    """The ID of the Geoscience Object schema."""
+
+    summary_attributes: SummaryAttributes
+    """Attributes containing summary statistics (mean, variance, min, max)."""
+
+    quantile_attributes: list[QuantileAttribute]
+    """List of attributes containing quantiles of the simulation results."""
+
+    simulations: TaskAttribute | None = None
+    """Attribute containing the simulation results."""
+
+    simulations_normal_score: TaskAttribute | None = None
+    """Attribute containing the simulation results in normal score space."""
+
+    point_simulations: TaskAttribute | None = None
+    """Attribute containing the point simulation results."""
+
+    point_simulations_normal_score: TaskAttribute | None = None
+    """Attribute containing the point simulation results in normal score space."""
+
+    loss_calculation_attribute: TaskAttribute | None = None
+    """Attribute containing the loss calculation results."""
+
+    validation_summary: ValidationSummary | None = None
+    """Summary of the validation results."""
+
+    validation_report: FileReference | None = None
+    """Link to the validation report file."""
+
+
+class ConsimResultModel(BaseModel):
+    """Raw API response model for conditional simulation.
+
+    This model matches the exact structure returned by the API.
+    """
+
+    target: ConsimTarget
+    """The target grid with simulation results."""
+
+    links: ConsimLinks
+    """Links related to the simulation task."""
+
+
+# =============================================================================
+# Result Wrapper
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    """Protocol for objects that can convert themselves to a DataFrame."""
+
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class ConsimResult:
+    """Result wrapper for conditional simulation tasks.
+
+    Provides convenient access to simulation outputs including summary statistics,
+    quantiles, individual simulations, and validation results.
+
+    Example:
+        >>> result = await run(manager, params, preview=True)
+        >>> print(result.message)
+        >>> print(result.mean_attribute_name)
+        >>> df = await result.to_dataframe("mean", "variance")
+        >>> target = await result.get_target_object()
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Conditional Simulation"
+
+    def __init__(self, context: IContext, model: ConsimResultModel) -> None:
+        self._target = model.target
+        self._links = model.links
+        self._context = context
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """Reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    # Summary attribute accessors
+    @property
+    def mean_attribute(self) -> TaskAttribute:
+        """Attribute containing the mean of simulations."""
+        return self._target.summary_attributes.mean
+
+    @property
+    def variance_attribute(self) -> TaskAttribute:
+        """Attribute containing the variance of simulations."""
+        return self._target.summary_attributes.variance
+
+    @property
+    def min_attribute(self) -> TaskAttribute:
+        """Attribute containing the minimum of simulations."""
+        return self._target.summary_attributes.min
+
+    @property
+    def max_attribute(self) -> TaskAttribute:
+        """Attribute containing the maximum of simulations."""
+        return self._target.summary_attributes.max
+
+    @property
+    def quantile_attributes(self) -> list[QuantileAttribute]:
+        """List of quantile attributes with their quantile values."""
+        return self._target.quantile_attributes
+
+    @property
+    def simulations_attribute(self) -> TaskAttribute | None:
+        """Attribute containing simulation realizations, if saved."""
+        return self._target.simulations
+
+    @property
+    def loss_calculation_attribute(self) -> TaskAttribute | None:
+        """Attribute containing loss calculation results, if computed."""
+        return self._target.loss_calculation_attribute
+
+    @property
+    def validation_summary(self) -> ValidationSummary | None:
+        """Summary of validation results, if validation was performed."""
+        return self._target.validation_summary
+
+    @property
+    def validation_report(self) -> FileReference | None:
+        """Reference to the validation report file, if generated."""
+        return self._target.validation_report
+
+    @property
+    def dashboard_link(self) -> str | None:
+        """Link to the validation dashboard, if available."""
+        return self._links.dashboard
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object.
+
+        Returns:
+            The typed geoscience object (e.g., Regular3DGrid, RegularMasked3DGrid)
+
+        Example:
+            >>> result = await run(manager, params)
+            >>> target = await result.get_target_object()
+        """
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Get the task results as a DataFrame.
+
+        Args:
+            columns: Optional list of column names to include. If empty, includes
+                    all columns. Common columns include 'mean', 'variance', 'min', 'max',
+                    and any quantile attributes.
+
+        Returns:
+            A pandas DataFrame containing the simulation results.
+
+        Example:
+            >>> result = await run(manager, params)
+            >>> df = await result.to_dataframe("mean", "variance")
+            >>> df.head()
+        """
+        target_obj = await self.get_target_object()
+
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        else:
+            raise TypeError(
+                f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+                "Use get_target_object() and access the data manually."
+            )
+
+    def __str__(self) -> str:
+        """String representation."""
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Target:    {self.target_name}",
+            f"  Mean:      {self.mean_attribute.name}",
+            f"  Variance:  {self.variance_attribute.name}",
+            f"  Quantiles: {len(self.quantile_attributes)} attributes",
+        ]
+        if self.simulations_attribute:
+            lines.append(f"  Simulations: {self.simulations_attribute.name}")
+        if self.validation_summary:
+            lines.append(f"  Validation: ref_mean={self.validation_summary.reference_mean:.4f}, sim_mean={self.validation_summary.mean:.4f}")
+        if self.dashboard_link:
+            lines.append(f"  Dashboard: {self.dashboard_link}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class ConsimRunner(
+    TaskRunner[ConsimParameters, ConsimResultModel, ConsimResult],
+    topic="geostatistics",
+    task="consim",
+):
+    """Runner for conditional simulation compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await ConsimRunner(context, params, preview=True)
+    """
+
+    async def _get_result(self, raw_result: ConsimResultModel) -> ConsimResult:
+        return ConsimResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_simulation_tasks.py
+++ b/packages/evo-compute/tests/test_simulation_tasks.py
@@ -1,0 +1,518 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for conditional simulation task parameter handling."""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from evo.objects import ObjectReference
+from evo.objects.typed.attributes import Attribute, PendingAttribute
+from pydantic import ValidationError
+
+from evo.compute.tasks import CreateAttribute, SearchNeighborhood, Source
+from evo.compute.tasks.common import Ellipsoid, EllipsoidRanges
+from evo.compute.tasks.common.results import TaskAttribute
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.simulation import (
+    ConsimLinks,
+    ConsimParameters,
+    ConsimResult,
+    ConsimResultModel,
+    ConsimRunner,
+    ConsimTarget,
+    Distribution,
+    LossCalculation,
+    LowerTail,
+    MaterialCategory,
+    QuantileAttribute,
+    ReportMeanThresholds,
+    SummaryAttributes,
+    TailExtrapolation,
+    UpperTail,
+    ValidationReportContext,
+    ValidationReportContextItem,
+    ValidationSummary,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    """Return a valid ObjectReference URL for testing."""
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+VARIOGRAM_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _create_mock_source_attribute(name: str, key: str, object_url: str, schema_path: str = "") -> MagicMock:
+    """Create a mock Attribute (existing) that passes isinstance checks."""
+    attr = MagicMock(spec=Attribute)
+    attr.name = name
+    attr.key = key
+    attr.exists = True
+
+    mock_context = MagicMock()
+    mock_context.schema_path = schema_path
+    attr._context = mock_context
+
+    mock_obj = MagicMock()
+    mock_obj.metadata.url = ObjectReference(object_url)
+    attr._obj = mock_obj
+
+    return attr
+
+
+def _create_pending_attribute(name: str, parent_obj: MagicMock | None = None) -> PendingAttribute:
+    """Create a real PendingAttribute with an optional mock parent."""
+    mock_parent = MagicMock()
+    mock_parent._obj = parent_obj
+    return PendingAttribute(mock_parent, name)
+
+
+# ---------------------------------------------------------------------------
+# Distribution Types Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTailExtrapolation(TestCase):
+    """Tests for tail extrapolation types."""
+
+    def test_upper_tail_valid(self):
+        """Test UpperTail with valid parameters."""
+        upper = UpperTail(power=0.5, max=10.0)
+        self.assertEqual(upper.power, 0.5)
+        self.assertEqual(upper.max, 10.0)
+
+    def test_upper_tail_power_boundary(self):
+        """Test UpperTail power must be >0 and <=1."""
+        # Valid at boundary
+        upper = UpperTail(power=1.0, max=10.0)
+        self.assertEqual(upper.power, 1.0)
+
+        # Invalid: power = 0
+        with self.assertRaises(ValidationError):
+            UpperTail(power=0.0, max=10.0)
+
+        # Invalid: power > 1
+        with self.assertRaises(ValidationError):
+            UpperTail(power=1.5, max=10.0)
+
+    def test_lower_tail_valid(self):
+        """Test LowerTail with valid parameters."""
+        lower = LowerTail(power=0.5, min=0.0)
+        self.assertEqual(lower.power, 0.5)
+        self.assertEqual(lower.min, 0.0)
+
+    def test_tail_extrapolation_upper_only(self):
+        """Test TailExtrapolation with only upper tail."""
+        tail = TailExtrapolation(upper=UpperTail(power=0.5, max=10.0))
+        self.assertIsNotNone(tail.upper)
+        self.assertIsNone(tail.lower)
+
+    def test_tail_extrapolation_both_tails(self):
+        """Test TailExtrapolation with both tails."""
+        tail = TailExtrapolation(
+            upper=UpperTail(power=0.5, max=10.0),
+            lower=LowerTail(power=0.5, min=0.0),
+        )
+        self.assertIsNotNone(tail.upper)
+        self.assertIsNotNone(tail.lower)
+
+
+class TestDistribution(TestCase):
+    """Tests for Distribution type."""
+
+    def test_distribution_basic(self):
+        """Test Distribution with basic configuration."""
+        dist = Distribution(
+            tail_extrapolation=TailExtrapolation(
+                upper=UpperTail(power=0.5, max=10.0),
+            ),
+        )
+        self.assertIsNotNone(dist.tail_extrapolation)
+        self.assertIsNone(dist.weights)
+
+    def test_distribution_with_weights(self):
+        """Test Distribution with weights attribute."""
+        dist = Distribution(
+            tail_extrapolation=TailExtrapolation(
+                upper=UpperTail(power=0.5, max=10.0),
+            ),
+            weights="weight_col",
+        )
+        self.assertEqual(dist.weights, "weight_col")
+
+
+# ---------------------------------------------------------------------------
+# Loss Calculation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialCategory(TestCase):
+    """Tests for MaterialCategory type."""
+
+    def test_material_category_minimal(self):
+        """Test MaterialCategory with only required fields."""
+        cat = MaterialCategory(
+            processing_cost=10.0,
+            mining_waste_cost=2.0,
+            mining_ore_cost=5.0,
+            metal_recovery_fraction=0.9,
+        )
+        self.assertEqual(cat.processing_cost, 10.0)
+        self.assertIsNone(cat.cutoff_grade)
+        self.assertIsNone(cat.label)
+
+    def test_material_category_full(self):
+        """Test MaterialCategory with all fields."""
+        cat = MaterialCategory(
+            cutoff_grade=0.5,
+            metal_price=1000.0,
+            label="Ore",
+            processing_cost=10.0,
+            mining_waste_cost=2.0,
+            mining_ore_cost=5.0,
+            metal_recovery_fraction=0.9,
+        )
+        self.assertEqual(cat.cutoff_grade, 0.5)
+        self.assertEqual(cat.label, "Ore")
+
+
+class TestLossCalculation(TestCase):
+    """Tests for LossCalculation type."""
+
+    def test_loss_calculation(self):
+        """Test LossCalculation configuration."""
+        loss = LossCalculation(
+            material_categories=[
+                MaterialCategory(
+                    label="Waste",
+                    processing_cost=0.0,
+                    mining_waste_cost=2.0,
+                    mining_ore_cost=0.0,
+                    metal_recovery_fraction=0.0,
+                ),
+                MaterialCategory(
+                    label="Ore",
+                    cutoff_grade=0.5,
+                    processing_cost=10.0,
+                    mining_waste_cost=0.0,
+                    mining_ore_cost=5.0,
+                    metal_recovery_fraction=0.9,
+                ),
+            ],
+            target_attribute=CreateAttribute(name="loss_results"),
+        )
+        self.assertEqual(len(loss.material_categories), 2)
+        self.assertEqual(loss.target_attribute.name, "loss_results")
+
+
+# ---------------------------------------------------------------------------
+# Validation Types Tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationTypes(TestCase):
+    """Tests for validation report types."""
+
+    def test_validation_report_context(self):
+        """Test ValidationReportContext configuration."""
+        context = ValidationReportContext(
+            title="Test Report",
+            details=[
+                ValidationReportContextItem(label="Domain", value="All"),
+                ValidationReportContextItem(label="Variable", value="grade"),
+            ],
+        )
+        self.assertEqual(context.title, "Test Report")
+        self.assertEqual(len(context.details), 2)
+
+    def test_report_mean_thresholds(self):
+        """Test ReportMeanThresholds configuration."""
+        thresholds = ReportMeanThresholds(acceptable=5.0, marginal=10.0)
+        self.assertEqual(thresholds.acceptable, 5.0)
+        self.assertEqual(thresholds.marginal, 10.0)
+
+
+# ---------------------------------------------------------------------------
+# ConsimParameters Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsimParameters(TestCase):
+    """Tests for ConsimParameters."""
+
+    def test_consim_params_minimal(self):
+        """Test ConsimParameters with minimal required fields."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+        )
+
+        self.assertIsNone(params.distribution)
+        self.assertEqual(params.kriging_method, "simple")
+        self.assertEqual(params.number_of_simulations, 1)
+        self.assertEqual(params.number_of_lines, 500)
+
+    def test_consim_params_with_distribution(self):
+        """Test ConsimParameters with distribution."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        dist = Distribution(
+            tail_extrapolation=TailExtrapolation(
+                upper=UpperTail(power=0.5, max=10.0),
+            ),
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+            distribution=dist,
+            number_of_simulations=100,
+            location_wise_quantiles=[0.1, 0.5, 0.9],
+        )
+
+        self.assertIsNotNone(params.distribution)
+        self.assertEqual(params.number_of_simulations, 100)
+        self.assertEqual(params.location_wise_quantiles, [0.1, 0.5, 0.9])
+
+    def test_consim_params_with_validation(self):
+        """Test ConsimParameters with validation enabled."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+            perform_validation=True,
+            report_context=ValidationReportContext(
+                title="Test",
+                details=[],
+            ),
+            report_mean_thresholds=ReportMeanThresholds(acceptable=5.0, marginal=10.0),
+        )
+
+        self.assertTrue(params.perform_validation)
+        self.assertIsNotNone(params.report_context)
+        self.assertIsNotNone(params.report_mean_thresholds)
+
+    def test_consim_params_serialization_splits_source(self):
+        """Test that serialization splits source into source_object and source_attribute."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+        )
+
+        params_dict = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+        # Should have source_object and source_attribute, not source
+        self.assertNotIn("source", params_dict)
+        self.assertEqual(params_dict["source_object"], POINTSET_URL)
+        self.assertEqual(params_dict["source_attribute"], "locations.attributes[?name=='grade']")
+
+    def test_consim_params_variogram_alias(self):
+        """Test that variogram is serialized as variogram_model."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+        )
+
+        params_dict = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+        self.assertEqual(params_dict["variogram_model"], VARIOGRAM_URL)
+
+    def test_consim_params_search_alias(self):
+        """Test that search is serialized as neighborhood."""
+        source = Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']")
+
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+        params = ConsimParameters(
+            source=source,
+            target_object=GRID_URL,
+            variogram=VARIOGRAM_URL,
+            search=search,
+        )
+
+        params_dict = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+        self.assertIn("neighborhood", params_dict)
+        self.assertNotIn("search", params_dict)
+
+
+# ---------------------------------------------------------------------------
+# ConsimRunner Registration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsimRunnerRegistration(TestCase):
+    """Tests for ConsimRunner auto-registration."""
+
+    def test_consim_runner_registered(self):
+        """Test ConsimRunner is registered with TaskRegistry."""
+        registry = TaskRegistry()
+        runner_cls = registry.get_runner(ConsimParameters)
+        self.assertIs(runner_cls, ConsimRunner)
+
+    def test_consim_runner_topic_and_task(self):
+        """Test ConsimRunner has correct topic and task."""
+        self.assertEqual(ConsimRunner.topic, "geostatistics")
+        self.assertEqual(ConsimRunner.task, "consim")
+
+    def test_consim_runner_type_params(self):
+        """Test ConsimRunner has correct type parameters."""
+        self.assertIs(ConsimRunner.params_type, ConsimParameters)
+        self.assertIs(ConsimRunner.result_model_type, ConsimResultModel)
+        self.assertIs(ConsimRunner.result_type, ConsimResult)
+
+
+# ---------------------------------------------------------------------------
+# ConsimResult Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsimResult(TestCase):
+    """Tests for ConsimResult wrapper."""
+
+    def _create_mock_result_model(self) -> ConsimResultModel:
+        """Create a mock result model for testing."""
+        return ConsimResultModel(
+            target=ConsimTarget(
+                reference=GRID_URL,
+                name="Test Grid",
+                description="Test description",
+                schema_id="regular-masked-3d-grid/1.2",
+                summary_attributes=SummaryAttributes(
+                    mean=TaskAttribute(reference="mean_ref", name="mean"),
+                    variance=TaskAttribute(reference="var_ref", name="variance"),
+                    min=TaskAttribute(reference="min_ref", name="min"),
+                    max=TaskAttribute(reference="max_ref", name="max"),
+                ),
+                quantile_attributes=[
+                    QuantileAttribute(reference="p10_ref", name="p10", quantile=0.1),
+                    QuantileAttribute(reference="p50_ref", name="p50", quantile=0.5),
+                    QuantileAttribute(reference="p90_ref", name="p90", quantile=0.9),
+                ],
+                simulations=TaskAttribute(reference="sim_ref", name="simulations"),
+                validation_summary=ValidationSummary(reference_mean=1.0, mean=0.98),
+            ),
+            links=ConsimLinks(dashboard="https://dashboard.example.com"),
+        )
+
+    def test_consim_result_properties(self):
+        """Test ConsimResult property accessors."""
+        model = self._create_mock_result_model()
+        context = MagicMock()
+        result = ConsimResult(context, model)
+
+        self.assertEqual(result.target_name, "Test Grid")
+        self.assertEqual(result.target_reference, GRID_URL)
+        self.assertEqual(result.mean_attribute.name, "mean")
+        self.assertEqual(result.variance_attribute.name, "variance")
+        self.assertEqual(result.min_attribute.name, "min")
+        self.assertEqual(result.max_attribute.name, "max")
+
+    def test_consim_result_quantiles(self):
+        """Test ConsimResult quantile accessors."""
+        model = self._create_mock_result_model()
+        context = MagicMock()
+        result = ConsimResult(context, model)
+
+        quantiles = result.quantile_attributes
+        self.assertEqual(len(quantiles), 3)
+        self.assertEqual(quantiles[0].quantile, 0.1)
+        self.assertEqual(quantiles[1].quantile, 0.5)
+        self.assertEqual(quantiles[2].quantile, 0.9)
+
+    def test_consim_result_validation(self):
+        """Test ConsimResult validation accessors."""
+        model = self._create_mock_result_model()
+        context = MagicMock()
+        result = ConsimResult(context, model)
+
+        self.assertIsNotNone(result.validation_summary)
+        self.assertEqual(result.validation_summary.reference_mean, 1.0)
+        self.assertEqual(result.validation_summary.mean, 0.98)
+
+    def test_consim_result_dashboard_link(self):
+        """Test ConsimResult dashboard link accessor."""
+        model = self._create_mock_result_model()
+        context = MagicMock()
+        result = ConsimResult(context, model)
+
+        self.assertEqual(result.dashboard_link, "https://dashboard.example.com")
+
+    def test_consim_result_str(self):
+        """Test ConsimResult string representation."""
+        model = self._create_mock_result_model()
+        context = MagicMock()
+        result = ConsimResult(context, model)
+
+        str_repr = str(result)
+        self.assertIn("Conditional Simulation", str_repr)
+        self.assertIn("Test Grid", str_repr)
+        self.assertIn("mean", str_repr)
+        self.assertIn("Dashboard", str_repr)
+
+    def test_consim_result_display_name(self):
+        """Test ConsimResult has correct display name."""
+        self.assertEqual(ConsimResult.TASK_DISPLAY_NAME, "Conditional Simulation")

--- a/packages/evo-widgets/src/evo/widgets/__init__.py
+++ b/packages/evo-widgets/src/evo/widgets/__init__.py
@@ -39,6 +39,7 @@ from .formatters import (
     format_block_model,
     format_block_model_attributes,
     format_block_model_version,
+    format_pointset,
     format_report,
     format_report_result,
     format_task_result_list,
@@ -118,6 +119,13 @@ def _register_formatters(ipython: InteractiveShell) -> None:
         "evo.objects.typed.variogram",
         "Variogram",
         format_variogram,
+    )
+
+    # Register formatter for PointSet (overrides BaseObject for pointset-specific rendering)
+    html_formatter.for_type_by_name(
+        "evo.objects.typed.pointset",
+        "PointSet",
+        format_pointset,
     )
 
     # Register formatter for Attributes collection

--- a/packages/evo-widgets/src/evo/widgets/formatters.py
+++ b/packages/evo-widgets/src/evo/widgets/formatters.py
@@ -39,6 +39,7 @@ __all__ = [
     "format_block_model",
     "format_block_model_attributes",
     "format_block_model_version",
+    "format_pointset",
     "format_report",
     "format_report_result",
     "format_task_result_list",
@@ -186,6 +187,60 @@ def format_base_object(obj: Any) -> str:
             rows.append((f"{dataset_name}:", attrs_table))
 
     return _build_html_from_rows(name, title_links, rows)
+
+
+def format_pointset(obj: Any) -> str:
+    """Format a PointSet object as HTML.
+
+    This formatter renders a pointset with its metadata, bounding box,
+    number of points, and attributes as a styled HTML table with Portal/Viewer links.
+
+    :param obj: A PointSet object from evo.objects.typed.pointset.
+    :return: HTML string representation.
+    """
+    doc = obj.as_dict()
+    name, title_links, rows = _get_base_metadata(obj)
+
+    # Add number of points
+    num_points = getattr(obj, "num_points", None)
+    if num_points is not None:
+        rows.append(("Points:", f"{num_points:,}"))
+
+    # Add bounding box if present
+    if bbox := doc.get("bounding_box"):
+        rows.append(("Bounding box:", _format_bounding_box(bbox)))
+
+    # Add CRS if present
+    if crs := doc.get("coordinate_reference_system"):
+        rows.append(("CRS:", _format_crs(crs)))
+
+    # Build the main table
+    table_rows = []
+    for label, value in rows:
+        if label == "Bounding box:":
+            table_rows.append(build_table_row_vtop(label, value))
+        else:
+            table_rows.append(build_table_row(label, value))
+
+    html = STYLESHEET
+    html += '<div class="evo">'
+    html += build_title(name, title_links)
+    html += f"<table>{''.join(table_rows)}</table>"
+
+    # Build attributes section
+    attrs = getattr(obj, "attributes", None)
+    if attrs and len(attrs) > 0:
+        attr_rows = []
+        for attr in attrs:
+            attr_info = attr.as_dict()
+            attr_name = attr_info.get("name", "Unknown")
+            attr_type = attr_info.get("attribute_type", "Unknown")
+            attr_rows.append([attr_name, attr_type])
+        attrs_table = build_nested_table(["Attribute", "Type"], attr_rows)
+        html += f'<div style="margin-top: 8px;"><strong>Attributes ({len(attrs)}):</strong></div>{attrs_table}'
+
+    html += "</div>"
+    return html
 
 
 def format_attributes_collection(obj: Any) -> str:


### PR DESCRIPTION
PR #235 is superseded by PR #267 and it will be closed.

Adds typed client support for the conditional simulation (turning bands) compute task, following the established kriging task pattern.

## Description

Add support for simulation workflow task, similar to the existing typed support for the kriging task. 
Additionally, included a formatter for pointset objects for a nice notebook view.

## Checklist

- [ x] I have read the contributing guide and the code of conduct
