### PR TITLE
Apply large_string fixes to dictionaries

### DIFF
--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.4.2"
+version = "0.4.3"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/src/evo/objects/utils/data.py
+++ b/packages/evo-objects/src/evo/objects/utils/data.py
@@ -73,6 +73,7 @@ def _get_schema_from_dataframe(dataframe: "pd.DataFrame") -> pa.Schema:
     This hook centralizes dataframe-to-Arrow schema adjustments before the
     dataframe is converted to a table. It currently performs these conversions:
     - large_string -> string
+    - dictionary<*, large_string> -> dictionary<*, string>
 
     :param dataframe: The pandas dataframe to get the schema from.
     :return: A pyarrow schema with any configured type conversions applied.
@@ -82,6 +83,8 @@ def _get_schema_from_dataframe(dataframe: "pd.DataFrame") -> pa.Schema:
     for field in schema:
         if pa.types.is_large_string(field.type):
             fields.append(field.with_type(pa.string()))
+        elif pa.types.is_dictionary(field.type) and pa.types.is_large_string(field.type.value_type):
+            fields.append(field.with_type(pa.dictionary(field.type.index_type, pa.string())))
         else:
             fields.append(field)
     return pa.schema(fields)


### PR DESCRIPTION
## Description

Extend the previous `large_string` fix to PyArrow dictionaries and hence to Evo category attributes.

## Checklist

- [x] I have read the contributing guide and the code of conduct
