### PR TITLE
Run update-changelog on daily schedule instead of on releases

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,8 +1,9 @@
 name: "Update Changelog"
 
 on:
-  release:
-    types: [released]
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
 
 jobs:
   update-changelog:
@@ -10,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,8 +46,27 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate GitHub App token
+      - name: Check for existing changelog PR
         if: steps.changes.outputs.has_changes == 'true'
+        id: existing-pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+            const existing = pullRequests.find(pr => pr.head.ref.startsWith('update-changelog-'));
+            if (existing) {
+              console.log(`Found existing changelog PR #${existing.number}: ${existing.html_url}`);
+              core.setOutput('pr_exists', 'true');
+            } else {
+              core.setOutput('pr_exists', 'false');
+            }
+
+      - name: Generate GitHub App token
+        if: steps.changes.outputs.has_changes == 'true' && steps.existing-pr.outputs.pr_exists == 'false'
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
@@ -54,22 +75,22 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Create PR with changes
-        if: steps.changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v8
+        if: steps.changes.outputs.has_changes == 'true' && steps.existing-pr.outputs.pr_exists == 'false'
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const script = require('${{ github.workspace }}/.github/scripts/create-verified-pr.js');
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const tagName = '${{ github.event.release.tag_name }}';
+            const runId = '${{ github.run_id }}';
             await script({
               github,
               context: {
                 ...context,
                 repo: { owner, repo },
-                commitMessage: `Update CHANGELOG.md for ${tagName}`,
-                branchName: `update-changelog-${tagName}`,
-                prTitle: `Update CHANGELOG.md for ${tagName}`,
-                prBody: `Automated update of CHANGELOG.md for release ${tagName}.`
+                commitMessage: 'Update CHANGELOG.md',
+                branchName: `update-changelog-${runId}`,
+                prTitle: 'Update CHANGELOG.md',
+                prBody: 'Automated daily update of CHANGELOG.md.'
               }
             });


### PR DESCRIPTION
## Description

Run update-changelog on daily schedule instead of on releases. PRs will also not be created if an update-changelog PR already exists, or if there are no changes.

## Checklist

- [x] I have read the contributing guide and the code of conduct
