### PR TITLE
Use correct extra for evo-blockmodels in evo-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "evo-sdk"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python SDK for using Seequent Evo"
 requires-python = ">=3.10"
 dependencies = [
     "evo-sdk-common[aiohttp,notebooks,jmespath]>=0.5.19",
     "evo-widgets>=0.2.0",
-    "evo-blockmodels[aiohttp,notebooks,pyarrow]>=0.2.0",
+    "evo-blockmodels[aiohttp,notebooks,utils]>=0.2.0",
     "evo-objects[aiohttp,notebooks,utils]>=0.4.0",
     "evo-files[aiohttp,notebooks]>=0.2.3",
     "evo-colormaps[aiohttp,notebooks]>=0.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "evo-blockmodels"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/evo-blockmodels" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -1073,7 +1073,7 @@ test = [
 
 [[package]]
 name = "evo-objects"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "packages/evo-objects" }
 dependencies = [
     { name = "evo-sdk-common", extra = ["jmespath"] },
@@ -1157,11 +1157,11 @@ test = [
 
 [[package]]
 name = "evo-sdk"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
-    { name = "evo-blockmodels", extra = ["aiohttp", "notebooks"] },
+    { name = "evo-blockmodels", extra = ["aiohttp", "notebooks", "utils"] },
     { name = "evo-colormaps", extra = ["aiohttp", "notebooks"] },
     { name = "evo-compute", extra = ["aiohttp", "notebooks"] },
     { name = "evo-files", extra = ["aiohttp", "notebooks"] },
@@ -1194,7 +1194,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.8" },
-    { name = "evo-blockmodels", extras = ["aiohttp", "notebooks", "pyarrow"], editable = "packages/evo-blockmodels" },
+    { name = "evo-blockmodels", extras = ["aiohttp", "notebooks", "utils"], editable = "packages/evo-blockmodels" },
     { name = "evo-colormaps", extras = ["aiohttp", "notebooks"], editable = "packages/evo-colormaps" },
     { name = "evo-compute", extras = ["aiohttp", "notebooks"], editable = "packages/evo-compute" },
     { name = "evo-files", extras = ["aiohttp", "notebooks"], editable = "packages/evo-files" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->
Currently the evo-blockmodels dependency in evo-sdk uses the `pyarrow` extra, which no longer exists as it was renamed to `utils`. This changes the requested extra to `utils`.

UV emitted warnings about this.

## Checklist

- [x] I have read the contributing guide and the code of conduct
