### PR TITLE
Add conditioned simulator (consim) task SDK client

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,9 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import conditioned_simulator as _conditioned_simulator_module  # noqa: F401
 
 # Shared components from common module
 from .common import (

--- a/packages/evo-compute/src/evo/compute/tasks/conditioned_simulator.py
+++ b/packages/evo-compute/src/evo/compute/tasks/conditioned_simulator.py
@@ -1,0 +1,385 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Conditional simulation (consim) compute task client.
+
+Full conditional turning-band simulation workflow: transforms source data to
+normal-score space, performs kriging + turning-band simulation on a target grid,
+and back-transforms results.  Supports optional loss calculation,
+location-wise quantile/summary statistics, and validation reporting.
+
+Example:
+    >>> from evo.compute.tasks import run
+    >>> from evo.compute.tasks.conditioned_simulator import (
+    ...     ConSimParameters,
+    ...     BlockDiscretization,
+    ... )
+    >>>
+    >>> params = ConSimParameters(
+    ...     source_object=pointset,
+    ...     source_attribute="locations.attributes[?name=='grade']",
+    ...     target_object=grid,
+    ...     variogram_model=variogram,
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(300, 200, 100)),
+    ...         max_samples=24,
+    ...     ),
+    ...     block_discretization=BlockDiscretization(nx=3, ny=3, nz=2),
+    ...     number_of_simulations=10,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+
+from .common import (
+    AnySourceAttribute,
+    AnyTargetAttribute,
+    CreateAttribute,
+    GeoscienceObjectReference,
+    SearchNeighborhood,
+    UpdateAttribute,
+)
+from .common.results import TaskAttribute
+from .common.runner import TaskRunner
+
+__all__ = [
+    "BlockDiscretization",
+    "ConSimLossCalculation",
+    "ConSimMaterialCategory",
+    "ConSimParameters",
+    "ConSimResult",
+    "ConSimResultModel",
+    "ConSimRunner",
+    "DistributionParams",
+    "ReportContext",
+    "ReportMeanThresholds",
+    "ValidationReportContextItem",
+]
+
+
+# =============================================================================
+# Supporting Types
+# =============================================================================
+
+
+class UpperTailParams(BaseModel):
+    """Upper tail extrapolation for the distribution."""
+
+    power: float = Field(gt=0.0, le=1.0)
+    max: float
+
+
+class LowerTailParams(BaseModel):
+    """Lower tail extrapolation for the distribution."""
+
+    power: float = Field(gt=0.0, le=1.0)
+    min: float
+
+
+class TailExtrapolationParams(BaseModel):
+    """Tail extrapolation parameters."""
+
+    upper: UpperTailParams
+    lower: LowerTailParams | None = None
+
+
+class DistributionParams(BaseModel):
+    """Parameters for the continuous distribution used for normal-score transformation."""
+
+    weights: str | None = None
+    """Optional weights attribute reference for weighted distribution."""
+
+    tail_extrapolation: TailExtrapolationParams | None = None
+    """Optional tail extrapolation parameters."""
+
+
+class BlockDiscretization(BaseModel):
+    """Sub-block discretization for support correction."""
+
+    nx: int = Field(1, ge=1, le=9)
+    ny: int = Field(1, ge=1, le=9)
+    nz: int = Field(1, ge=1, le=9)
+
+
+class ConSimMaterialCategory(BaseModel):
+    """Material category for loss calculation within simulation."""
+
+    cutoff_grade: float = Field(ge=0.0)
+    metal_price: float = Field(ge=0.0)
+    label: str
+
+
+class ConSimLossCalculation(BaseModel):
+    """Settings for loss calculation within the simulation."""
+
+    material_categories: list[ConSimMaterialCategory]
+    processing_cost: float = Field(ge=0.0)
+    mining_waste_cost: float = Field(ge=0.0)
+    mining_ore_cost: float = Field(ge=0.0)
+    metal_recovery_fraction: float = Field(ge=0.0, le=1.0)
+    target_attribute: CreateAttribute | UpdateAttribute
+
+
+class ValidationReportContextItem(BaseModel):
+    """A single item of contextual information for the validation report."""
+
+    label: str
+    value: str
+
+
+class ReportContext(BaseModel):
+    """Context for the validation report."""
+
+    title: str
+    details: list[ValidationReportContextItem] = Field(min_length=1, max_length=10)
+
+
+class ReportMeanThresholds(BaseModel):
+    """Thresholds for mean comparison in the validation report."""
+
+    acceptable: float = Field(ge=0.0)
+    marginal: float = Field(ge=0.0)
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class ConSimParameters(BaseModel):
+    """Parameters for the conditional simulation (consim) task.
+
+    This is the most comprehensive geostatistics compute task, supporting
+    the full conditional turning-band simulation workflow.
+    """
+
+    source_object: GeoscienceObjectReference
+    """Reference to the pointset containing source conditioning points."""
+
+    source_attribute: str
+    """Attribute reference for the source values."""
+
+    target_object: GeoscienceObjectReference
+    """Reference to the target 3D grid."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighborhood for conditioning."""
+
+    variogram_model: GeoscienceObjectReference
+    """Reference to the variogram model."""
+
+    block_discretization: BlockDiscretization = Field(default_factory=BlockDiscretization)
+    """Sub-block discretization for support correction."""
+
+    distribution: DistributionParams | None = None
+    """Optional distribution parameters for normal-score transformation."""
+
+    kriging_method: Literal["simple", "ordinary"] = "simple"
+    """The kriging method for conditioning (default: simple)."""
+
+    number_of_lines: int = Field(500, ge=1, le=1000)
+    """Number of lines for turning-band simulation."""
+
+    number_of_simulations: int = Field(1, ge=1, le=100)
+    """Number of simulations to run."""
+
+    random_seed: int = 38239342
+    """Random seed for simulation and tie-breaking."""
+
+    number_of_simulations_to_save: int = Field(5, ge=0, le=100)
+    """Number of simulations to publish to the output object."""
+
+    loss_calculation: ConSimLossCalculation | None = None
+    """Optional loss calculation settings."""
+
+    location_wise_quantiles: list[float] | None = None
+    """Optional list of quantiles to compute for each location."""
+
+    perform_validation: bool = False
+    """Whether to run validation and generate a validation report."""
+
+    report_context: ReportContext | None = None
+    """Optional context for the validation report."""
+
+    report_mean_thresholds: ReportMeanThresholds | None = None
+    """Optional thresholds for mean comparison in the validation report."""
+
+
+# =============================================================================
+# Result Types
+# =============================================================================
+
+
+class ConSimSummaryAttributes(BaseModel):
+    """Summary statistic attributes from the simulation."""
+
+    mean: TaskAttribute
+    variance: TaskAttribute
+    min: TaskAttribute
+    max: TaskAttribute
+
+
+class ConSimQuantileAttribute(BaseModel):
+    """A quantile attribute from the simulation results."""
+
+    reference: str
+    name: str
+    quantile: float
+
+
+class ConSimValidationSummary(BaseModel):
+    """Summary of validation results."""
+
+    reference_mean: float
+    mean: float
+
+
+class ConSimValidationReport(BaseModel):
+    """Reference to the validation report file."""
+
+    reference: str
+    name: str
+
+
+class ConSimLinks(BaseModel):
+    """Links related to the simulation task."""
+
+    dashboard: str | None = None
+
+
+class ConSimTargetResult(BaseModel):
+    """Target grid result with all simulation outputs."""
+
+    reference: str
+    name: str
+    description: str | None = None
+    schema_id: str
+    summary_attributes: ConSimSummaryAttributes
+    quantile_attributes: list[ConSimQuantileAttribute] | None = None
+    simulations: TaskAttribute | None = None
+    simulations_normal_score: TaskAttribute | None = None
+    point_simulations: TaskAttribute | None = None
+    point_simulations_normal_score: TaskAttribute | None = None
+    loss_calculation_attribute: TaskAttribute | None = None
+
+
+class ConSimResultModel(BaseModel):
+    """Pydantic model for the raw consim task result."""
+
+    target: ConSimTargetResult
+    validation_summary: ConSimValidationSummary | None = None
+    validation_report: ConSimValidationReport | None = None
+    links: ConSimLinks
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class ConSimResult:
+    TASK_DISPLAY_NAME: ClassVar[str] = "Conditional Simulation"
+
+    def __init__(self, context: IContext, model: ConSimResultModel) -> None:
+        self._target = model.target
+        self._validation_summary = model.validation_summary
+        self._validation_report = model.validation_report
+        self._links = model.links
+        self._context = context
+
+    @property
+    def target_name(self) -> str:
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        return self._target.reference
+
+    @property
+    def schema(self) -> ObjectSchema:
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    @property
+    def summary_attributes(self) -> ConSimSummaryAttributes:
+        """Summary statistics (mean, variance, min, max) attribute references."""
+        return self._target.summary_attributes
+
+    @property
+    def quantile_attributes(self) -> list[ConSimQuantileAttribute]:
+        """Quantile attribute references, if computed."""
+        return self._target.quantile_attributes or []
+
+    @property
+    def simulations_attribute(self) -> TaskAttribute | None:
+        """Ensemble attribute containing saved simulations."""
+        return self._target.simulations
+
+    @property
+    def loss_calculation_attribute(self) -> TaskAttribute | None:
+        """Category attribute containing loss calculation results."""
+        return self._target.loss_calculation_attribute
+
+    @property
+    def validation_summary(self) -> ConSimValidationSummary | None:
+        return self._validation_summary
+
+    @property
+    def dashboard_url(self) -> str | None:
+        return self._links.dashboard
+
+    async def get_target_object(self) -> BaseObject:
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        target_obj = await self.get_target_object()
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        raise TypeError(
+            f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+            "Use get_target_object() and access the data manually."
+        )
+
+    def __str__(self) -> str:
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Target:     {self.target_name}",
+            f"  Mean attr:  {self.summary_attributes.mean.name}",
+            f"  Var attr:   {self.summary_attributes.variance.name}",
+        ]
+        if self._validation_summary:
+            lines.append(f"  Ref mean:   {self._validation_summary.reference_mean:.4f}")
+            lines.append(f"  Sim mean:   {self._validation_summary.mean:.4f}")
+        if self._links.dashboard:
+            lines.append(f"  Dashboard:  {self._links.dashboard}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class ConSimRunner(
+    TaskRunner[ConSimParameters, ConSimResultModel, ConSimResult],
+    topic="geostatistics",
+    task="consim",
+):
+    async def _get_result(self, raw_result: ConSimResultModel) -> ConSimResult:
+        return ConSimResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_conditioned_simulator_tasks.py
+++ b/packages/evo-compute/tests/test_conditioned_simulator_tasks.py
@@ -1,0 +1,272 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License")
+
+"""Tests for conditioned simulator (consim) task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import Ellipsoid, EllipsoidRanges
+from evo.compute.tasks.common.results import TaskAttribute
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.conditioned_simulator import (
+    BlockDiscretization,
+    ConSimLossCalculation,
+    ConSimMaterialCategory,
+    ConSimParameters,
+    ConSimResult,
+    ConSimResultModel,
+    ConSimRunner,
+    ConSimSummaryAttributes,
+    ConSimTargetResult,
+    ConSimLinks,
+    ConSimValidationSummary,
+    DistributionParams,
+    ReportContext,
+    ReportMeanThresholds,
+    TailExtrapolationParams,
+    UpperTailParams,
+    ValidationReportContextItem,
+)
+from evo.compute.tasks.common import CreateAttribute
+
+# ---------------------------------------------------------------------------
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+VARIOGRAM_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=300, semi_major=200, minor=100)),
+        max_samples=24,
+    )
+
+
+def _params(**kwargs) -> ConSimParameters:
+    defaults = dict(
+        source_object=POINTSET_URL,
+        source_attribute="locations.attributes[?name=='grade']",
+        target_object=GRID_URL,
+        neighborhood=_search(),
+        variogram_model=VARIOGRAM_URL,
+    )
+    defaults.update(kwargs)
+    return ConSimParameters(**defaults)
+
+
+def _dump(params: ConSimParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> ConSimResultModel:
+    return ConSimResultModel(
+        target=ConSimTargetResult(
+            reference=GRID_URL,
+            name="SimGrid",
+            schema_id="/objects/regular-3d-grid/1.3.0/regular-3d-grid.schema.json",
+            summary_attributes=ConSimSummaryAttributes(
+                mean=TaskAttribute(reference="ref_mean", name="sim_mean"),
+                variance=TaskAttribute(reference="ref_var", name="sim_var"),
+                min=TaskAttribute(reference="ref_min", name="sim_min"),
+                max=TaskAttribute(reference="ref_max", name="sim_max"),
+            ),
+        ),
+        links=ConSimLinks(),
+    )
+
+
+# ---------------------------------------------------------------------------
+class TestConSimRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(ConSimParameters)
+        self.assertIs(runner_cls, ConSimRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(ConSimRunner.topic, "geostatistics")
+        self.assertEqual(ConSimRunner.task, "consim")
+
+    def test_runner_types(self):
+        self.assertIs(ConSimRunner.params_type, ConSimParameters)
+        self.assertIs(ConSimRunner.result_model_type, ConSimResultModel)
+        self.assertIs(ConSimRunner.result_type, ConSimResult)
+
+
+# ---------------------------------------------------------------------------
+class TestBlockDiscretization(unittest.TestCase):
+    def test_defaults(self):
+        bd = BlockDiscretization()
+        self.assertEqual(bd.nx, 1)
+        self.assertEqual(bd.ny, 1)
+        self.assertEqual(bd.nz, 1)
+
+    def test_custom(self):
+        bd = BlockDiscretization(nx=3, ny=3, nz=2)
+        d = bd.model_dump(mode="json")
+        self.assertEqual(d["nx"], 3)
+        self.assertEqual(d["nz"], 2)
+
+
+# ---------------------------------------------------------------------------
+class TestConSimParametersSerialization(unittest.TestCase):
+    def test_basic(self):
+        d = _dump(_params())
+        self.assertEqual(d["source_object"], POINTSET_URL)
+        self.assertEqual(d["source_attribute"], "locations.attributes[?name=='grade']")
+        self.assertEqual(d["target_object"], GRID_URL)
+        self.assertEqual(d["variogram_model"], VARIOGRAM_URL)
+
+    def test_defaults(self):
+        d = _dump(_params())
+        self.assertEqual(d["kriging_method"], "simple")
+        self.assertEqual(d["number_of_lines"], 500)
+        self.assertEqual(d["number_of_simulations"], 1)
+        self.assertEqual(d["random_seed"], 38239342)
+        self.assertEqual(d["number_of_simulations_to_save"], 5)
+        self.assertFalse(d["perform_validation"])
+
+    def test_block_discretization_default(self):
+        d = _dump(_params())
+        self.assertEqual(d["block_discretization"]["nx"], 1)
+
+    def test_custom_simulations(self):
+        d = _dump(_params(number_of_simulations=10, number_of_simulations_to_save=3))
+        self.assertEqual(d["number_of_simulations"], 10)
+        self.assertEqual(d["number_of_simulations_to_save"], 3)
+
+    def test_distribution_params(self):
+        params = _params(
+            distribution=DistributionParams(
+                tail_extrapolation=TailExtrapolationParams(
+                    upper=UpperTailParams(power=0.5, max=100.0),
+                ),
+            ),
+        )
+        d = _dump(params)
+        self.assertEqual(d["distribution"]["tail_extrapolation"]["upper"]["power"], 0.5)
+
+    def test_loss_calculation_params(self):
+        params = _params(
+            loss_calculation=ConSimLossCalculation(
+                material_categories=[
+                    ConSimMaterialCategory(cutoff_grade=0.0, metal_price=0, label="waste"),
+                    ConSimMaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore"),
+                ],
+                processing_cost=20.0,
+                mining_waste_cost=5.0,
+                mining_ore_cost=10.0,
+                metal_recovery_fraction=0.85,
+                target_attribute=CreateAttribute(name="loss_cat"),
+            ),
+        )
+        d = _dump(params)
+        lc = d["loss_calculation"]
+        self.assertEqual(len(lc["material_categories"]), 2)
+        self.assertEqual(lc["processing_cost"], 20.0)
+
+    def test_location_wise_quantiles(self):
+        params = _params(location_wise_quantiles=[0.1, 0.5, 0.9])
+        d = _dump(params)
+        self.assertEqual(d["location_wise_quantiles"], [0.1, 0.5, 0.9])
+
+    def test_report_context(self):
+        params = _params(
+            perform_validation=True,
+            report_context=ReportContext(
+                title="Simulation QC",
+                details=[ValidationReportContextItem(label="Deposit", value="TestDeposit")],
+            ),
+        )
+        d = _dump(params)
+        self.assertTrue(d["perform_validation"])
+        self.assertEqual(d["report_context"]["title"], "Simulation QC")
+
+    def test_report_mean_thresholds(self):
+        params = _params(
+            report_mean_thresholds=ReportMeanThresholds(acceptable=0.02, marginal=0.05),
+        )
+        d = _dump(params)
+        self.assertEqual(d["report_mean_thresholds"]["acceptable"], 0.02)
+
+
+# ---------------------------------------------------------------------------
+class TestConSimResult(unittest.TestCase):
+    def _make_result(self) -> ConSimResult:
+        return ConSimResult(MagicMock(), _make_result_model())
+
+    def test_target_name(self):
+        self.assertEqual(self._make_result().target_name, "SimGrid")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make_result().target_reference, GRID_URL)
+
+    def test_summary_attributes(self):
+        r = self._make_result()
+        self.assertEqual(r.summary_attributes.mean.name, "sim_mean")
+        self.assertEqual(r.summary_attributes.variance.name, "sim_var")
+
+    def test_quantile_attributes_empty(self):
+        r = self._make_result()
+        self.assertEqual(r.quantile_attributes, [])
+
+    def test_validation_summary_none(self):
+        r = self._make_result()
+        self.assertIsNone(r.validation_summary)
+
+    def test_dashboard_url_none(self):
+        r = self._make_result()
+        self.assertIsNone(r.dashboard_url)
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Conditional Simulation", s)
+        self.assertIn("sim_mean", s)
+
+    def test_with_validation(self):
+        model = _make_result_model()
+        model.validation_summary = ConSimValidationSummary(reference_mean=5.5, mean=5.3)
+        r = ConSimResult(MagicMock(), model)
+        s = str(r)
+        self.assertIn("5.5", s)
+
+
+# ---------------------------------------------------------------------------
+class TestConSimRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await ConSimRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "consim")
+        self.assertIsInstance(result, ConSimResult)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **conditioned simulator (consim)** geostatistics compute task (`evo.compute.tasks.conditioned_simulator`).

### Changes
- Add `ConSimParameters` model with full type coverage (neighborhood, variogram, block discretization, etc.)
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.conditioned_simulator import ConSimParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes