### PR TITLE
Add normal-score compute task SDK client

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,9 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import normal_score as _normal_score_module  # noqa: F401
 
 # Shared components from common module
 from .common import (

--- a/packages/evo-compute/src/evo/compute/tasks/normal_score.py
+++ b/packages/evo-compute/src/evo/compute/tasks/normal_score.py
@@ -1,0 +1,220 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Normal-score transform compute task client.
+
+This module provides typed dataclass models and convenience functions for running
+the Normal Score task (geostatistics/normal-score).
+
+Two transform directions are available:
+
+- **Forward**: transforms data values to standard Gaussian (normal-score) space.
+- **Backward**: transforms normal-score values back to the original data space.
+
+Both transforms require a pre-existing continuous distribution object.
+The ``method`` field selects the transform direction.
+
+Example:
+    >>> from evo.compute.tasks import run, Source, Target, CreateAttribute
+    >>> from evo.compute.tasks.normal_score import NormalScoreParameters
+    >>>
+    >>> params = NormalScoreParameters(
+    ...     method="forward",
+    ...     source=Source(object=pointset_url, attribute="locations.attributes[0]"),
+    ...     target=Target(
+    ...         object=pointset_url,
+    ...         attribute=CreateAttribute(name="grade_ns"),
+    ...     ),
+    ...     distribution=distribution_url,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel
+
+from .common import (
+    AnySourceAttribute,
+    AnyTargetAttribute,
+    GeoscienceObjectReference,
+)
+from .common.results import TaskTarget
+from .common.runner import TaskRunner
+
+__all__ = [
+    "NormalScoreParameters",
+    "NormalScoreResult",
+    "NormalScoreResultModel",
+    "NormalScoreRunner",
+]
+
+
+# =============================================================================
+# Normal Score Parameters
+# =============================================================================
+
+
+class NormalScoreParameters(BaseModel):
+    """Parameters for the normal-score compute task.
+
+    Set ``method="forward"`` to transform from data space to Gaussian,
+    or ``method="backward"`` to transform from Gaussian back to data space.
+
+    Example:
+        >>> params = NormalScoreParameters(
+        ...     method="forward",
+        ...     source=Source(object=pointset_url, attribute="locations.attributes[0]"),
+        ...     target=Target(
+        ...         object=pointset_url,
+        ...         attribute=CreateAttribute(name="grade_ns"),
+        ...     ),
+        ...     distribution=distribution_url,
+        ... )
+    """
+
+    method: Literal["forward", "backward"]
+    """Transform direction: ``"forward"`` (data → Gaussian) or ``"backward"`` (Gaussian → data)."""
+
+    source: AnySourceAttribute
+    """The source object and attribute containing values to transform."""
+
+    target: AnyTargetAttribute
+    """The target object and attribute to create or update with transformed values."""
+
+    distribution: GeoscienceObjectReference
+    """Reference URL to the continuous distribution object used for the transform."""
+
+
+# =============================================================================
+# Normal Score Result Types
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    """Protocol for objects that can convert themselves to a DataFrame."""
+
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class NormalScoreResultModel(BaseModel):
+    """Pydantic model for the raw normal-score task result."""
+
+    message: str
+    """A message describing what happened in the task."""
+
+    target: TaskTarget
+    """Target information from the task result."""
+
+
+class NormalScoreResult:
+    """Result of a normal-score transform task.
+
+    Provides access to the target object and the created/updated attribute.
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Normal Score"
+
+    def __init__(self, context: IContext, model: NormalScoreResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        """A message describing what happened in the task."""
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """The reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        """The name of the attribute that was created/updated."""
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object.
+
+        Returns:
+            The typed geoscience object (e.g., PointSet)
+        """
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Get the task results as a DataFrame.
+
+        Args:
+            columns: Optional column names to include. If omitted, returns all.
+
+        Returns:
+            A pandas DataFrame containing the transformed attribute values.
+        """
+        target_obj = await self.get_target_object()
+
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        else:
+            raise TypeError(
+                f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+                "Use get_target_object() and access the data manually."
+            )
+
+    def __str__(self) -> str:
+        """String representation."""
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:   {self.message}",
+            f"  Target:    {self.target_name}",
+            f"  Attribute: {self.attribute_name}",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class NormalScoreRunner(
+    TaskRunner[NormalScoreParameters, NormalScoreResultModel, NormalScoreResult],
+    topic="geostatistics",
+    task="normal-score",
+):
+    """Runner for normal-score compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await NormalScoreRunner(context, params)
+    """
+
+    async def _get_result(self, raw_result: NormalScoreResultModel) -> NormalScoreResult:
+        return NormalScoreResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_normal_score_tasks.py
+++ b/packages/evo-compute/tests/test_normal_score_tasks.py
@@ -1,0 +1,257 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for normal-score task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import (
+    CreateAttribute,
+    Source,
+    Target,
+    UpdateAttribute,
+)
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.normal_score import (
+    NormalScoreParameters,
+    NormalScoreResult,
+    NormalScoreResultModel,
+    NormalScoreRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+TARGET_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+DIST_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _params(**kwargs) -> NormalScoreParameters:
+    defaults = dict(
+        method="forward",
+        source=Source(object=POINTSET_URL, attribute="locations.attributes[0]"),
+        target=Target(object=TARGET_URL, attribute=CreateAttribute(name="grade_ns")),
+        distribution=DIST_URL,
+    )
+    defaults.update(kwargs)
+    return NormalScoreParameters(**defaults)
+
+
+def _dump(params: NormalScoreParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model(
+    target_name: str = "MyPointset",
+    attr_name: str = "grade_ns",
+) -> NormalScoreResultModel:
+    return NormalScoreResultModel(
+        message="Normal score transform completed successfully.",
+        target=TaskTarget(
+            reference=TARGET_URL,
+            name=target_name,
+            description=None,
+            schema_id="/objects/pointset/1.3.0/pointset.schema.json",
+            attribute=TaskAttribute(
+                reference="locations.attributes[?name=='grade_ns']",
+                name=attr_name,
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalScoreRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(NormalScoreParameters)
+        self.assertIs(runner_cls, NormalScoreRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(NormalScoreRunner.topic, "geostatistics")
+        self.assertEqual(NormalScoreRunner.task, "normal-score")
+
+    def test_runner_types(self):
+        self.assertIs(NormalScoreRunner.params_type, NormalScoreParameters)
+        self.assertIs(NormalScoreRunner.result_model_type, NormalScoreResultModel)
+        self.assertIs(NormalScoreRunner.result_type, NormalScoreResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalScoreParametersSerialization(unittest.TestCase):
+    def test_forward_method(self):
+        d = _dump(_params(method="forward"))
+        self.assertEqual(d["method"], "forward")
+
+    def test_backward_method(self):
+        d = _dump(_params(method="backward"))
+        self.assertEqual(d["method"], "backward")
+
+    def test_source_new_format(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], POINTSET_URL)
+        self.assertEqual(d["source"]["attribute"], "locations.attributes[0]")
+
+    def test_target_with_create_attribute(self):
+        d = _dump(_params())
+        self.assertEqual(d["target"]["object"], TARGET_URL)
+        self.assertEqual(d["target"]["attribute"]["name"], "grade_ns")
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+
+    def test_target_with_update_attribute(self):
+        d = _dump(_params(
+            target=Target(
+                object=TARGET_URL,
+                attribute=UpdateAttribute(reference="locations.attributes[?name=='grade_ns']"),
+            ),
+        ))
+        self.assertEqual(d["target"]["attribute"]["operation"], "update")
+
+    def test_distribution_is_url(self):
+        d = _dump(_params())
+        self.assertEqual(d["distribution"], DIST_URL)
+
+    def test_invalid_method_rejected(self):
+        with self.assertRaises(Exception):
+            _params(method="invalid")
+
+    def test_full_serialization(self):
+        d = _dump(_params())
+        self.assertIn("method", d)
+        self.assertIn("source", d)
+        self.assertIn("target", d)
+        self.assertIn("distribution", d)
+
+
+# ---------------------------------------------------------------------------
+# Result model tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalScoreResultModel(unittest.TestCase):
+    def test_result_model_validate(self):
+        data = {
+            "message": "ok",
+            "target": {
+                "reference": TARGET_URL,
+                "name": "target",
+                "schema_id": "/objects/pointset/1.3.0/pointset.schema.json",
+                "attribute": {"reference": "attr_ref", "name": "attr_name"},
+            },
+        }
+        model = NormalScoreResultModel.model_validate(data)
+        self.assertIsInstance(model, NormalScoreResultModel)
+        self.assertEqual(model.message, "ok")
+
+    def test_result_model_target_attribute(self):
+        model = _make_result_model()
+        self.assertEqual(model.target.attribute.name, "grade_ns")
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalScoreResult(unittest.TestCase):
+    def _make_result(self) -> NormalScoreResult:
+        return NormalScoreResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("completed", self._make_result().message)
+
+    def test_target_name(self):
+        self.assertEqual(self._make_result().target_name, "MyPointset")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make_result().target_reference, TARGET_URL)
+
+    def test_attribute_name(self):
+        self.assertEqual(self._make_result().attribute_name, "grade_ns")
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Normal Score", s)
+        self.assertIn("grade_ns", s)
+
+
+# ---------------------------------------------------------------------------
+# Runner behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalScoreRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        connector = MagicMock()
+        context = MagicMock()
+        context.get_connector.return_value = connector
+        context.get_org_id.return_value = "test-org-id"
+        return context
+
+    def _make_job(self):
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+        return job
+
+    async def test_runner_submits_with_correct_topic_and_task(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            result = await NormalScoreRunner(context, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "normal-score")
+        self.assertIsInstance(result, NormalScoreResult)
+
+    async def test_runner_preview_defaults_false(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            await NormalScoreRunner(context, params)
+
+        _, kwargs = mock_submit.call_args
+        self.assertFalse(kwargs.get("preview", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **normal-score** geostatistics compute task (`evo.compute.tasks.normal_score`), supporting both forward and backward transforms.

### Changes
- Add `NormalScoreParameters` model with full type coverage
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.normal_score import NormalScoreParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes