### PR TITLE
Add profit-calculation task SDK client

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,10 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import loss_calculation as _loss_calculation_module  # noqa: F401
+from . import profit_calculation as _profit_calculation_module  # noqa: F401
 
 # Shared components from common module
 from .common import (

--- a/packages/evo-compute/src/evo/compute/tasks/loss_calculation.py
+++ b/packages/evo-compute/src/evo/compute/tasks/loss_calculation.py
@@ -1,0 +1,177 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Loss calculation compute task client.
+
+Classifies grid cells into material categories (ore/waste) based on ensemble
+simulation data and economic parameters.  Each cell is assigned the category
+that minimises the expected economic loss.
+
+Example:
+    >>> from evo.compute.tasks import run
+    >>> from evo.compute.tasks.loss_calculation import (
+    ...     LossCalculationParameters,
+    ...     MaterialCategory,
+    ... )
+    >>>
+    >>> params = LossCalculationParameters(
+    ...     source=grid.attributes["simulations"],
+    ...     target=Target.new_attribute(grid, "loss_category"),
+    ...     material_categories=[
+    ...         MaterialCategory(cutoff_grade=0.0, metal_price=0, label="waste"),
+    ...         MaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore"),
+    ...     ],
+    ...     processing_cost=20.0,
+    ...     mining_waste_cost=5.0,
+    ...     mining_ore_cost=10.0,
+    ...     metal_recovery_fraction=0.85,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field
+
+from .common import AnySourceAttribute, AnyTargetAttribute
+from .common.results import TaskAttribute, TaskTarget
+from .common.runner import TaskRunner
+
+__all__ = [
+    "LossCalculationParameters",
+    "LossCalculationResult",
+    "LossCalculationResultModel",
+    "LossCalculationRunner",
+    "MaterialCategory",
+]
+
+
+class MaterialCategory(BaseModel):
+    """A material category for grade calculations.
+
+    Each category is defined by a cutoff grade, metal price, and label.
+    Categories should be ordered from lowest to highest cutoff grade.
+    """
+
+    cutoff_grade: float = Field(0.0, ge=0.0)
+    """The cutoff grade for this category."""
+
+    metal_price: float = Field(0.0, ge=0.0)
+    """The metal price per unit for this category."""
+
+    label: str = "waste"
+    """Label for the material category (e.g. 'ore', 'waste')."""
+
+
+class LossCalculationParameters(BaseModel):
+    """Parameters for the loss-calculation task.
+
+    Classifies grid cells into material categories based on ensemble data
+    and economic parameters, minimising expected economic loss.
+    """
+
+    source: AnySourceAttribute
+    """The source object and attribute containing ensemble simulation values."""
+
+    target: AnyTargetAttribute
+    """The target object and attribute to create or update with grade categories."""
+
+    material_categories: list[MaterialCategory]
+    """List of material categories, ordered from lowest to highest cutoff grade."""
+
+    processing_cost: float = Field(ge=0.0)
+    """Processing cost per unit of material."""
+
+    mining_waste_cost: float = Field(ge=0.0)
+    """Mining cost per unit of waste material."""
+
+    mining_ore_cost: float = Field(ge=0.0)
+    """Mining cost per unit of ore material."""
+
+    metal_recovery_fraction: float = Field(ge=0.0, le=1.0)
+    """Fraction of metal expected to be recovered during processing (0.0–1.0)."""
+
+
+class LossCalculationResultModel(BaseModel):
+    """Pydantic model for the raw loss-calculation task result."""
+
+    message: str
+    target: TaskTarget
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class LossCalculationResult:
+    TASK_DISPLAY_NAME: ClassVar[str] = "Loss Calculation"
+
+    def __init__(self, context: IContext, model: LossCalculationResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        target_obj = await self.get_target_object()
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        raise TypeError(
+            f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+            "Use get_target_object() and access the data manually."
+        )
+
+    def __str__(self) -> str:
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:   {self.message}",
+            f"  Target:    {self.target_name}",
+            f"  Attribute: {self.attribute_name}",
+        ]
+        return "\n".join(lines)
+
+
+class LossCalculationRunner(
+    TaskRunner[LossCalculationParameters, LossCalculationResultModel, LossCalculationResult],
+    topic="geostatistics",
+    task="loss-calculation",
+):
+    async def _get_result(self, raw_result: LossCalculationResultModel) -> LossCalculationResult:
+        return LossCalculationResult(self._context, raw_result)

--- a/packages/evo-compute/src/evo/compute/tasks/profit_calculation.py
+++ b/packages/evo-compute/src/evo/compute/tasks/profit_calculation.py
@@ -1,0 +1,163 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Profit calculation compute task client.
+
+Classifies grid cells into material categories (ore/waste) based on ensemble
+simulation data and economic parameters, maximising expected profit.
+
+Uses the same parameter schema as loss-calculation but applies a different
+economic calculation.
+
+Example:
+    >>> from evo.compute.tasks import run
+    >>> from evo.compute.tasks.profit_calculation import (
+    ...     ProfitCalculationParameters,
+    ...     MaterialCategory,
+    ... )
+    >>>
+    >>> params = ProfitCalculationParameters(
+    ...     source=grid.attributes["simulations"],
+    ...     target=Target.new_attribute(grid, "profit_category"),
+    ...     material_categories=[
+    ...         MaterialCategory(cutoff_grade=0.0, metal_price=0, label="waste"),
+    ...         MaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore"),
+    ...     ],
+    ...     processing_cost=20.0,
+    ...     mining_waste_cost=5.0,
+    ...     mining_ore_cost=10.0,
+    ...     metal_recovery_fraction=0.85,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field
+
+from .common import AnySourceAttribute, AnyTargetAttribute
+from .common.results import TaskAttribute, TaskTarget
+from .common.runner import TaskRunner
+from .loss_calculation import MaterialCategory
+
+__all__ = [
+    "MaterialCategory",
+    "ProfitCalculationParameters",
+    "ProfitCalculationResult",
+    "ProfitCalculationResultModel",
+    "ProfitCalculationRunner",
+]
+
+
+class ProfitCalculationParameters(BaseModel):
+    """Parameters for the profit-calculation task.
+
+    Same parameter schema as loss-calculation: classifies grid cells into
+    material categories based on ensemble data and economic parameters.
+    """
+
+    source: AnySourceAttribute
+    """The source object and attribute containing ensemble simulation values."""
+
+    target: AnyTargetAttribute
+    """The target object and attribute to create or update with grade categories."""
+
+    material_categories: list[MaterialCategory]
+    """List of material categories, ordered from lowest to highest cutoff grade."""
+
+    processing_cost: float = Field(ge=0.0)
+    """Processing cost per unit of material."""
+
+    mining_waste_cost: float = Field(ge=0.0)
+    """Mining cost per unit of waste material."""
+
+    mining_ore_cost: float = Field(ge=0.0)
+    """Mining cost per unit of ore material."""
+
+    metal_recovery_fraction: float = Field(ge=0.0, le=1.0)
+    """Fraction of metal expected to be recovered during processing (0.0–1.0)."""
+
+
+class ProfitCalculationResultModel(BaseModel):
+    """Pydantic model for the raw profit-calculation task result."""
+
+    message: str
+    target: TaskTarget
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class ProfitCalculationResult:
+    TASK_DISPLAY_NAME: ClassVar[str] = "Profit Calculation"
+
+    def __init__(self, context: IContext, model: ProfitCalculationResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        target_obj = await self.get_target_object()
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        raise TypeError(
+            f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+            "Use get_target_object() and access the data manually."
+        )
+
+    def __str__(self) -> str:
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:   {self.message}",
+            f"  Target:    {self.target_name}",
+            f"  Attribute: {self.attribute_name}",
+        ]
+        return "\n".join(lines)
+
+
+class ProfitCalculationRunner(
+    TaskRunner[ProfitCalculationParameters, ProfitCalculationResultModel, ProfitCalculationResult],
+    topic="geostatistics",
+    task="profit-calculation",
+):
+    async def _get_result(self, raw_result: ProfitCalculationResultModel) -> ProfitCalculationResult:
+        return ProfitCalculationResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_loss_calculation_tasks.py
+++ b/packages/evo-compute/tests/test_loss_calculation_tasks.py
@@ -1,0 +1,191 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License")
+
+"""Tests for loss-calculation task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import CreateAttribute, Source, Target, UpdateAttribute
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.loss_calculation import (
+    LossCalculationParameters,
+    LossCalculationResult,
+    LossCalculationResultModel,
+    LossCalculationRunner,
+    MaterialCategory,
+)
+
+# ---------------------------------------------------------------------------
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+TARGET_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+
+_CATEGORIES = [
+    MaterialCategory(cutoff_grade=0.0, metal_price=0, label="waste"),
+    MaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore"),
+]
+
+
+def _params(**kwargs) -> LossCalculationParameters:
+    defaults = dict(
+        source=Source(object=GRID_URL, attribute="cell_attributes[?name=='simulations']"),
+        target=Target(object=TARGET_URL, attribute=CreateAttribute(name="loss_cat")),
+        material_categories=_CATEGORIES,
+        processing_cost=20.0,
+        mining_waste_cost=5.0,
+        mining_ore_cost=10.0,
+        metal_recovery_fraction=0.85,
+    )
+    defaults.update(kwargs)
+    return LossCalculationParameters(**defaults)
+
+
+def _dump(params: LossCalculationParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> LossCalculationResultModel:
+    return LossCalculationResultModel(
+        message="Loss calculation completed successfully.",
+        target=TaskTarget(
+            reference=TARGET_URL,
+            name="MyGrid",
+            schema_id="/objects/regular-3d-grid/1.3.0/regular-3d-grid.schema.json",
+            attribute=TaskAttribute(reference="cell_attributes[?name=='loss_cat']", name="loss_cat"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+class TestLossCalcRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(LossCalculationParameters)
+        self.assertIs(runner_cls, LossCalculationRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(LossCalculationRunner.topic, "geostatistics")
+        self.assertEqual(LossCalculationRunner.task, "loss-calculation")
+
+    def test_runner_types(self):
+        self.assertIs(LossCalculationRunner.params_type, LossCalculationParameters)
+        self.assertIs(LossCalculationRunner.result_model_type, LossCalculationResultModel)
+        self.assertIs(LossCalculationRunner.result_type, LossCalculationResult)
+
+
+# ---------------------------------------------------------------------------
+class TestMaterialCategory(unittest.TestCase):
+    def test_default_values(self):
+        cat = MaterialCategory()
+        self.assertEqual(cat.cutoff_grade, 0.0)
+        self.assertEqual(cat.metal_price, 0.0)
+        self.assertEqual(cat.label, "waste")
+
+    def test_custom_values(self):
+        cat = MaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore")
+        self.assertEqual(cat.cutoff_grade, 0.5)
+        self.assertEqual(cat.metal_price, 200)
+        self.assertEqual(cat.label, "ore")
+
+    def test_serialization(self):
+        cat = MaterialCategory(cutoff_grade=0.3, metal_price=150, label="low_grade")
+        d = cat.model_dump(mode="json")
+        self.assertEqual(d["cutoff_grade"], 0.3)
+        self.assertEqual(d["metal_price"], 150)
+        self.assertEqual(d["label"], "low_grade")
+
+
+# ---------------------------------------------------------------------------
+class TestLossCalcParametersSerialization(unittest.TestCase):
+    def test_source_serializes(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], GRID_URL)
+
+    def test_target_create(self):
+        d = _dump(_params())
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+        self.assertEqual(d["target"]["attribute"]["name"], "loss_cat")
+
+    def test_target_update(self):
+        params = _params(target=Target(object=TARGET_URL, attribute=UpdateAttribute(reference="attr_ref")))
+        d = _dump(params)
+        self.assertEqual(d["target"]["attribute"]["operation"], "update")
+
+    def test_material_categories_serialized(self):
+        d = _dump(_params())
+        cats = d["material_categories"]
+        self.assertEqual(len(cats), 2)
+        self.assertEqual(cats[0]["label"], "waste")
+        self.assertEqual(cats[1]["label"], "ore")
+        self.assertEqual(cats[1]["cutoff_grade"], 0.5)
+
+    def test_economic_params(self):
+        d = _dump(_params())
+        self.assertEqual(d["processing_cost"], 20.0)
+        self.assertEqual(d["mining_waste_cost"], 5.0)
+        self.assertEqual(d["mining_ore_cost"], 10.0)
+        self.assertEqual(d["metal_recovery_fraction"], 0.85)
+
+
+# ---------------------------------------------------------------------------
+class TestLossCalcResult(unittest.TestCase):
+    def _make_result(self) -> LossCalculationResult:
+        return LossCalculationResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("successfully", self._make_result().message)
+
+    def test_target_name(self):
+        self.assertEqual(self._make_result().target_name, "MyGrid")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make_result().target_reference, TARGET_URL)
+
+    def test_attribute_name(self):
+        self.assertEqual(self._make_result().attribute_name, "loss_cat")
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Loss Calculation", s)
+        self.assertIn("loss_cat", s)
+
+
+# ---------------------------------------------------------------------------
+class TestLossCalcRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await LossCalculationRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "loss-calculation")
+        self.assertIsInstance(result, LossCalculationResult)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/evo-compute/tests/test_profit_calculation_tasks.py
+++ b/packages/evo-compute/tests/test_profit_calculation_tasks.py
@@ -1,0 +1,161 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License")
+
+"""Tests for profit-calculation task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import CreateAttribute, Source, Target, UpdateAttribute
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.loss_calculation import MaterialCategory
+from evo.compute.tasks.profit_calculation import (
+    ProfitCalculationParameters,
+    ProfitCalculationResult,
+    ProfitCalculationResultModel,
+    ProfitCalculationRunner,
+)
+
+# ---------------------------------------------------------------------------
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+TARGET_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+
+_CATEGORIES = [
+    MaterialCategory(cutoff_grade=0.0, metal_price=0, label="waste"),
+    MaterialCategory(cutoff_grade=0.5, metal_price=200, label="ore"),
+]
+
+
+def _params(**kwargs) -> ProfitCalculationParameters:
+    defaults = dict(
+        source=Source(object=GRID_URL, attribute="cell_attributes[?name=='simulations']"),
+        target=Target(object=TARGET_URL, attribute=CreateAttribute(name="profit_cat")),
+        material_categories=_CATEGORIES,
+        processing_cost=20.0,
+        mining_waste_cost=5.0,
+        mining_ore_cost=10.0,
+        metal_recovery_fraction=0.85,
+    )
+    defaults.update(kwargs)
+    return ProfitCalculationParameters(**defaults)
+
+
+def _dump(params: ProfitCalculationParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> ProfitCalculationResultModel:
+    return ProfitCalculationResultModel(
+        message="Profit calculation completed successfully.",
+        target=TaskTarget(
+            reference=TARGET_URL,
+            name="MyGrid",
+            schema_id="/objects/regular-3d-grid/1.3.0/regular-3d-grid.schema.json",
+            attribute=TaskAttribute(reference="cell_attributes[?name=='profit_cat']", name="profit_cat"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+class TestProfitCalcRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(ProfitCalculationParameters)
+        self.assertIs(runner_cls, ProfitCalculationRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(ProfitCalculationRunner.topic, "geostatistics")
+        self.assertEqual(ProfitCalculationRunner.task, "profit-calculation")
+
+    def test_runner_types(self):
+        self.assertIs(ProfitCalculationRunner.params_type, ProfitCalculationParameters)
+        self.assertIs(ProfitCalculationRunner.result_model_type, ProfitCalculationResultModel)
+        self.assertIs(ProfitCalculationRunner.result_type, ProfitCalculationResult)
+
+
+# ---------------------------------------------------------------------------
+class TestProfitCalcParametersSerialization(unittest.TestCase):
+    def test_source_serializes(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], GRID_URL)
+
+    def test_target_create(self):
+        d = _dump(_params())
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+        self.assertEqual(d["target"]["attribute"]["name"], "profit_cat")
+
+    def test_material_categories(self):
+        d = _dump(_params())
+        self.assertEqual(len(d["material_categories"]), 2)
+        self.assertEqual(d["material_categories"][1]["metal_price"], 200)
+
+    def test_economic_params(self):
+        d = _dump(_params())
+        self.assertEqual(d["processing_cost"], 20.0)
+        self.assertEqual(d["metal_recovery_fraction"], 0.85)
+
+    def test_reuses_material_category(self):
+        """MaterialCategory is imported from loss_calculation module."""
+        from evo.compute.tasks.profit_calculation import MaterialCategory as MC
+        self.assertIs(MC, MaterialCategory)
+
+
+# ---------------------------------------------------------------------------
+class TestProfitCalcResult(unittest.TestCase):
+    def _make_result(self) -> ProfitCalculationResult:
+        return ProfitCalculationResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("successfully", self._make_result().message)
+
+    def test_target_name(self):
+        self.assertEqual(self._make_result().target_name, "MyGrid")
+
+    def test_attribute_name(self):
+        self.assertEqual(self._make_result().attribute_name, "profit_cat")
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Profit Calculation", s)
+        self.assertIn("profit_cat", s)
+
+
+# ---------------------------------------------------------------------------
+class TestProfitCalcRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await ProfitCalculationRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "profit-calculation")
+        self.assertIsInstance(result, ProfitCalculationResult)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **profit-calculation** geostatistics compute task (`evo.compute.tasks.profit_calculation`).

### Changes
- Add `ProfitCalculationParameters` model with full type coverage
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.profit_calculation import ProfitCalculationParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes