### PR TITLE
Add continuous-distribution task SDK client

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,9 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import continuous_distribution as _continuous_distribution_module  # noqa: F401
 
 # Shared components from common module
 from .common import (

--- a/packages/evo-compute/src/evo/compute/tasks/continuous_distribution.py
+++ b/packages/evo-compute/src/evo/compute/tasks/continuous_distribution.py
@@ -1,0 +1,203 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Continuous distribution compute task client.
+
+Creates a non-parametric continuous cumulative distribution from a set of
+source values, with optional weights and tail extrapolation.
+
+Example:
+    >>> from evo.compute.tasks import run
+    >>> from evo.compute.tasks.continuous_distribution import (
+    ...     ContinuousDistributionParameters,
+    ...     DistributionTarget,
+    ... )
+    >>>
+    >>> params = ContinuousDistributionParameters(
+    ...     source=pointset.attributes["grade"],
+    ...     target=DistributionTarget(reference=dist_url),
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from evo.common import IContext
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field
+
+from .common import AnySourceAttribute, GeoscienceObjectReference
+from .common.runner import TaskRunner
+
+__all__ = [
+    "ContinuousDistributionParameters",
+    "ContinuousDistributionResult",
+    "ContinuousDistributionResultModel",
+    "ContinuousDistributionRunner",
+    "DistributionTarget",
+    "TailExtrapolation",
+    "UpperTail",
+    "LowerTail",
+]
+
+
+# =============================================================================
+# Tail Extrapolation
+# =============================================================================
+
+
+class UpperTail(BaseModel):
+    """Power model for extrapolating the upper tail of the distribution."""
+
+    power: float = Field(gt=0.0, le=1.0)
+    """Denominator of the exponent for the power model (0 < power <= 1)."""
+
+    max: float
+    """Maximum extent of tail, must be greater than the maximum value in the data."""
+
+
+class LowerTail(BaseModel):
+    """Power model for extrapolating the lower tail of the distribution."""
+
+    power: float = Field(gt=0.0, le=1.0)
+    """Denominator of the exponent for the power model (0 < power <= 1)."""
+
+    min: float
+    """Minimum extent of tail, must be less than the minimum value in the data."""
+
+
+class TailExtrapolation(BaseModel):
+    """Parameters for extending the distribution beyond the data range."""
+
+    upper: UpperTail
+    """Upper tail extrapolation parameters."""
+
+    lower: LowerTail | None = None
+    """Optional lower tail extrapolation parameters."""
+
+
+# =============================================================================
+# Target and Source
+# =============================================================================
+
+
+class DistributionTarget(BaseModel):
+    """Target specifying where to create the continuous distribution object."""
+
+    reference: GeoscienceObjectReference
+    """Reference to the target distribution object."""
+
+    overwrite: bool = False
+    """Whether to overwrite an existing object."""
+
+    description: str | None = None
+    """Description to put into the target object."""
+
+    tags: dict[str, str] = Field(default_factory=dict)
+    """Tags to put into the target object."""
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class ContinuousDistributionParameters(BaseModel):
+    """Parameters for the continuous-distribution task."""
+
+    source: AnySourceAttribute
+    """The source object and attribute containing values to create a distribution from."""
+
+    weights: AnySourceAttribute | None = None
+    """Optional weights for creating a weighted (declustered) distribution."""
+
+    tail_extrapolation: TailExtrapolation | None = None
+    """Optional tail extrapolation parameters."""
+
+    target: DistributionTarget
+    """Target specifying where to create the distribution object."""
+
+
+# =============================================================================
+# Result Types
+# =============================================================================
+
+
+class DistributionOutput(BaseModel):
+    """Reference to the created distribution object."""
+
+    reference: str
+    name: str
+    description: str | None = None
+    schema_id: str
+
+
+class ContinuousDistributionResultModel(BaseModel):
+    """Pydantic model for the raw continuous-distribution task result."""
+
+    message: str
+    distribution: DistributionOutput
+
+
+class ContinuousDistributionResult:
+    TASK_DISPLAY_NAME: ClassVar[str] = "Continuous Distribution"
+
+    def __init__(self, context: IContext, model: ContinuousDistributionResultModel) -> None:
+        self._distribution = model.distribution
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @property
+    def distribution_name(self) -> str:
+        """The name of the created distribution object."""
+        return self._distribution.name
+
+    @property
+    def distribution_reference(self) -> str:
+        """Reference URL to the distribution object."""
+        return self._distribution.reference
+
+    @property
+    def schema(self) -> ObjectSchema:
+        return ObjectSchema.from_id(self._distribution.schema_id)
+
+    async def get_distribution_object(self) -> BaseObject:
+        """Load and return the created distribution object."""
+        return await object_from_reference(self._context, self._distribution.reference)
+
+    def __str__(self) -> str:
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:      {self.message}",
+            f"  Distribution: {self.distribution_name}",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class ContinuousDistributionRunner(
+    TaskRunner[ContinuousDistributionParameters, ContinuousDistributionResultModel, ContinuousDistributionResult],
+    topic="geostatistics",
+    task="continuous-distribution",
+):
+    async def _get_result(self, raw_result: ContinuousDistributionResultModel) -> ContinuousDistributionResult:
+        return ContinuousDistributionResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_continuous_distribution_tasks.py
+++ b/packages/evo-compute/tests/test_continuous_distribution_tasks.py
@@ -1,0 +1,198 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License")
+
+"""Tests for continuous-distribution task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import Source
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.continuous_distribution import (
+    ContinuousDistributionParameters,
+    ContinuousDistributionResult,
+    ContinuousDistributionResultModel,
+    ContinuousDistributionRunner,
+    DistributionOutput,
+    DistributionTarget,
+    LowerTail,
+    TailExtrapolation,
+    UpperTail,
+)
+
+# ---------------------------------------------------------------------------
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+DIST_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _params(**kwargs) -> ContinuousDistributionParameters:
+    defaults = dict(
+        source=Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']"),
+        target=DistributionTarget(reference=DIST_URL),
+    )
+    defaults.update(kwargs)
+    return ContinuousDistributionParameters(**defaults)
+
+
+def _dump(params: ContinuousDistributionParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> ContinuousDistributionResultModel:
+    return ContinuousDistributionResultModel(
+        message="Distribution created successfully.",
+        distribution=DistributionOutput(
+            reference=DIST_URL,
+            name="grade_dist",
+            description="Grade distribution",
+            schema_id="/objects/distribution/1.0.0/distribution.schema.json",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+class TestCDRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(ContinuousDistributionParameters)
+        self.assertIs(runner_cls, ContinuousDistributionRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(ContinuousDistributionRunner.topic, "geostatistics")
+        self.assertEqual(ContinuousDistributionRunner.task, "continuous-distribution")
+
+    def test_runner_types(self):
+        self.assertIs(ContinuousDistributionRunner.params_type, ContinuousDistributionParameters)
+        self.assertIs(ContinuousDistributionRunner.result_model_type, ContinuousDistributionResultModel)
+        self.assertIs(ContinuousDistributionRunner.result_type, ContinuousDistributionResult)
+
+
+# ---------------------------------------------------------------------------
+class TestTailExtrapolation(unittest.TestCase):
+    def test_upper_tail(self):
+        t = UpperTail(power=0.5, max=100.0)
+        self.assertEqual(t.power, 0.5)
+        self.assertEqual(t.max, 100.0)
+
+    def test_lower_tail(self):
+        t = LowerTail(power=0.3, min=-5.0)
+        self.assertEqual(t.power, 0.3)
+        self.assertEqual(t.min, -5.0)
+
+    def test_tail_extrapolation_upper_only(self):
+        te = TailExtrapolation(upper=UpperTail(power=0.5, max=100.0))
+        d = te.model_dump(mode="json", exclude_none=True)
+        self.assertIn("upper", d)
+        self.assertNotIn("lower", d)
+
+    def test_tail_extrapolation_both(self):
+        te = TailExtrapolation(
+            upper=UpperTail(power=0.5, max=100.0),
+            lower=LowerTail(power=0.3, min=-5.0),
+        )
+        d = te.model_dump(mode="json", exclude_none=True)
+        self.assertIn("upper", d)
+        self.assertIn("lower", d)
+
+
+# ---------------------------------------------------------------------------
+class TestDistributionTarget(unittest.TestCase):
+    def test_defaults(self):
+        t = DistributionTarget(reference=DIST_URL)
+        self.assertFalse(t.overwrite)
+        self.assertIsNone(t.description)
+        self.assertEqual(t.tags, {})
+
+    def test_with_overwrite_and_tags(self):
+        t = DistributionTarget(reference=DIST_URL, overwrite=True, tags={"env": "test"})
+        d = t.model_dump(mode="json", exclude_none=True)
+        self.assertTrue(d["overwrite"])
+        self.assertEqual(d["tags"]["env"], "test")
+
+
+# ---------------------------------------------------------------------------
+class TestCDParametersSerialization(unittest.TestCase):
+    def test_basic_serialization(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], POINTSET_URL)
+        self.assertEqual(d["target"]["reference"], DIST_URL)
+        self.assertNotIn("weights", d)
+        self.assertNotIn("tail_extrapolation", d)
+
+    def test_with_weights(self):
+        params = _params(
+            weights=Source(object=POINTSET_URL, attribute="locations.attributes[?name=='weight']"),
+        )
+        d = _dump(params)
+        self.assertEqual(d["weights"]["object"], POINTSET_URL)
+
+    def test_with_tail_extrapolation(self):
+        params = _params(
+            tail_extrapolation=TailExtrapolation(
+                upper=UpperTail(power=0.5, max=100.0),
+                lower=LowerTail(power=0.3, min=-5.0),
+            ),
+        )
+        d = _dump(params)
+        self.assertEqual(d["tail_extrapolation"]["upper"]["power"], 0.5)
+        self.assertEqual(d["tail_extrapolation"]["lower"]["min"], -5.0)
+
+
+# ---------------------------------------------------------------------------
+class TestCDResult(unittest.TestCase):
+    def _make_result(self) -> ContinuousDistributionResult:
+        return ContinuousDistributionResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("successfully", self._make_result().message)
+
+    def test_distribution_name(self):
+        self.assertEqual(self._make_result().distribution_name, "grade_dist")
+
+    def test_distribution_reference(self):
+        self.assertEqual(self._make_result().distribution_reference, DIST_URL)
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Continuous Distribution", s)
+        self.assertIn("grade_dist", s)
+
+
+# ---------------------------------------------------------------------------
+class TestCDRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await ContinuousDistributionRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "continuous-distribution")
+        self.assertIsInstance(result, ContinuousDistributionResult)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **continuous-distribution** geostatistics compute task (`evo.compute.tasks.continuous_distribution`).

### Changes
- Add `ContinuousDistributionParameters` model with full type coverage
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.continuous_distribution import ContinuousDistributionParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes