### PR TITLE
Add simulation-report compute task SDK client

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -36,8 +36,9 @@ from evo.common import IContext
 from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
-# Import kriging module to trigger registration
+# Import task modules to trigger registration
 from . import kriging as _kriging_module  # noqa: F401
+from . import simulation_report as _simulation_report_module  # noqa: F401
 
 # Shared components from common module
 from .common import (

--- a/packages/evo-compute/src/evo/compute/tasks/simulation_report.py
+++ b/packages/evo-compute/src/evo/compute/tasks/simulation_report.py
@@ -1,0 +1,330 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Simulation report compute task client.
+
+This module provides typed dataclass models and convenience functions for running
+the Simulation Report task (geostatistics/simulation-report).
+
+Generates a validation report for a conditional turning-band simulation,
+including variogram reproduction statistics, summary metrics, and an
+optional interactive dashboard.
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood
+    >>> from evo.compute.tasks.simulation_report import (
+    ...     SimulationReportParameters,
+    ...     SimulationReportBlockDiscretization,
+    ... )
+    >>>
+    >>> params = SimulationReportParameters(
+    ...     simulation_source=pointset_url,
+    ...     source_attribute="locations.attributes[0]",
+    ...     simulation_target=grid_url,
+    ...     point_simulations="cell_attributes[0]",
+    ...     point_simulations_normal_score="cell_attributes[1]",
+    ...     block_simulations="cell_attributes[2]",
+    ...     block_simulations_normal_score="cell_attributes[3]",
+    ...     variogram_model=variogram_url,
+    ...     neighborhood=SearchNeighborhood(...),
+    ...     block_discretization=SimulationReportBlockDiscretization(nx=2, ny=2, nz=2),
+    ...     number_of_simulations=50,
+    ...     random_seed=38239342,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from evo.common import IContext
+from pydantic import BaseModel, Field
+
+from .common import (
+    GeoscienceObjectReference,
+    SearchNeighborhood,
+)
+from .common.runner import TaskRunner
+
+__all__ = [
+    "SimReportContext",
+    "SimReportContextItem",
+    "SimReportThresholds",
+    "SimulationReportBlockDiscretization",
+    "SimulationReportDistribution",
+    "SimulationReportParameters",
+    "SimulationReportResult",
+    "SimulationReportResultModel",
+    "SimulationReportRunner",
+]
+
+
+# =============================================================================
+# Supporting Types
+# =============================================================================
+
+
+class SimulationReportBlockDiscretization(BaseModel):
+    """Sub-block discretization for support correction.
+
+    Controls how each block is subdivided for point-to-block variance correction.
+    Each dimension must be between 1 and 9 inclusive.
+    """
+
+    nx: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the X axis."""
+
+    ny: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the Y axis."""
+
+    nz: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the Z axis."""
+
+
+class SimulationReportDistribution(BaseModel):
+    """Optional distribution settings for the simulation report.
+
+    When provided, the report includes distribution-related validation.
+    """
+
+    tail_extrapolation: None = None
+    """Reserved for future tail-extrapolation options."""
+
+    weights: str | None = None
+    """Optional attribute expression for sample weights."""
+
+
+class SimReportContextItem(BaseModel):
+    """Single key-value detail for a simulation report."""
+
+    label: str
+    """Display label for this detail."""
+
+    value: str
+    """Display value for this detail."""
+
+
+class SimReportContext(BaseModel):
+    """Report context metadata.
+
+    Adds a title and descriptive details to the generated validation report.
+    """
+
+    title: str
+    """Title for the validation report."""
+
+    details: list[SimReportContextItem] = Field(default_factory=list)
+    """Key-value details to include in the report header."""
+
+
+class SimReportThresholds(BaseModel):
+    """Acceptable/marginal thresholds for mean validation.
+
+    Used to classify the difference between reference mean and simulation mean.
+    """
+
+    acceptable: float = Field(ge=0.0)
+    """Maximum difference considered acceptable."""
+
+    marginal: float = Field(ge=0.0)
+    """Maximum difference considered marginal (between acceptable and failing)."""
+
+
+# =============================================================================
+# Simulation Report Parameters
+# =============================================================================
+
+
+class SimulationReportParameters(BaseModel):
+    """Parameters for the simulation-report compute task.
+
+    All simulation data references use flat string fields (object URLs and
+    attribute expressions) rather than nested Source/Target objects.
+
+    Example:
+        >>> params = SimulationReportParameters(
+        ...     simulation_source=pointset_url,
+        ...     source_attribute="locations.attributes[0]",
+        ...     simulation_target=grid_url,
+        ...     point_simulations="cell_attributes[0]",
+        ...     point_simulations_normal_score="cell_attributes[1]",
+        ...     block_simulations="cell_attributes[2]",
+        ...     block_simulations_normal_score="cell_attributes[3]",
+        ...     variogram_model=variogram_url,
+        ...     neighborhood=SearchNeighborhood(...),
+        ...     number_of_simulations=50,
+        ...     random_seed=38239342,
+        ... )
+    """
+
+    simulation_source: GeoscienceObjectReference
+    """Reference URL to the source geoscience object (typically a pointset)."""
+
+    source_attribute: str
+    """Attribute expression on the source object (e.g. ``"locations.attributes[0]"``)."""
+
+    simulation_target: GeoscienceObjectReference
+    """Reference URL to the target geoscience object (typically a block model)."""
+
+    point_simulations: str
+    """Attribute expression for point simulations on the target."""
+
+    point_simulations_normal_score: str
+    """Attribute expression for point simulation normal scores on the target."""
+
+    block_simulations: str
+    """Attribute expression for block simulations on the target."""
+
+    block_simulations_normal_score: str
+    """Attribute expression for block simulation normal scores on the target."""
+
+    variogram_model: GeoscienceObjectReference
+    """Reference URL to the variogram model object."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighborhood parameters for kriging within the report."""
+
+    block_discretization: SimulationReportBlockDiscretization = Field(
+        default_factory=SimulationReportBlockDiscretization
+    )
+    """Sub-block discretization for support correction."""
+
+    distribution: SimulationReportDistribution | None = None
+    """Optional distribution settings."""
+
+    number_of_simulations: int = Field(ge=1)
+    """Number of simulation realizations to validate."""
+
+    random_seed: int = 38239342
+    """Seed for the random number generator."""
+
+    kriging_method: Literal["simple", "ordinary"] = "simple"
+    """Kriging method used in the simulation."""
+
+    number_of_lines: int = Field(500, ge=1)
+    """Number of turning-band lines."""
+
+    report_context: SimReportContext | None = None
+    """Optional report context metadata."""
+
+    report_mean_thresholds: SimReportThresholds | None = None
+    """Optional thresholds for mean comparison validation."""
+
+
+# =============================================================================
+# Simulation Report Result Types
+# =============================================================================
+
+
+class SimReportValidationSummary(BaseModel):
+    """Validation summary from the simulation report."""
+
+    reference_mean: float
+    """Mean of the reference (source) data."""
+
+    mean: float
+    """Mean of the simulated data."""
+
+
+class SimReportValidationReport(BaseModel):
+    """Reference to the generated validation report file."""
+
+    reference: str
+    """URL to the generated report file."""
+
+
+class SimReportLinks(BaseModel):
+    """Links associated with the simulation report result."""
+
+    dashboard: str | None = None
+    """URL to an interactive dashboard (if generated)."""
+
+
+class SimulationReportResultModel(BaseModel):
+    """Pydantic model for the raw simulation-report task result."""
+
+    validation_summary: SimReportValidationSummary | None = None
+    """Summary comparing reference and simulated means."""
+
+    validation_report: SimReportValidationReport | None = None
+    """Reference to the generated validation report."""
+
+    links: SimReportLinks | None = None
+    """Links to additional resources like dashboards."""
+
+
+class SimulationReportResult:
+    """Result of a simulation-report task.
+
+    Provides access to validation summary, report reference, and dashboard link.
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Simulation Report"
+
+    def __init__(self, context: IContext, model: SimulationReportResultModel) -> None:
+        self._validation_summary = model.validation_summary
+        self._validation_report = model.validation_report
+        self._links = model.links
+        self._context = context
+
+    @property
+    def validation_summary(self) -> SimReportValidationSummary | None:
+        """Validation summary comparing reference and simulated means."""
+        return self._validation_summary
+
+    @property
+    def report_reference(self) -> str | None:
+        """URL to the generated validation report file."""
+        if self._validation_report:
+            return self._validation_report.reference
+        return None
+
+    @property
+    def dashboard_url(self) -> str | None:
+        """URL to the interactive dashboard (if available)."""
+        if self._links:
+            return self._links.dashboard
+        return None
+
+    def __str__(self) -> str:
+        """String representation."""
+        lines = [f"✓ {self.TASK_DISPLAY_NAME} Result"]
+        if self._validation_summary:
+            lines.append(f"  Ref mean:   {self._validation_summary.reference_mean:.4f}")
+            lines.append(f"  Sim mean:   {self._validation_summary.mean:.4f}")
+        if self._validation_report:
+            lines.append(f"  Report:     {self._validation_report.reference}")
+        if self._links and self._links.dashboard:
+            lines.append(f"  Dashboard:  {self._links.dashboard}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class SimulationReportRunner(
+    TaskRunner[SimulationReportParameters, SimulationReportResultModel, SimulationReportResult],
+    topic="geostatistics",
+    task="simulation-report",
+):
+    """Runner for simulation-report compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await SimulationReportRunner(context, params)
+    """
+
+    async def _get_result(self, raw_result: SimulationReportResultModel) -> SimulationReportResult:
+        return SimulationReportResult(self._context, raw_result)

--- a/packages/evo-compute/tests/test_simulation_report_tasks.py
+++ b/packages/evo-compute/tests/test_simulation_report_tasks.py
@@ -1,0 +1,329 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for simulation-report task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import Ellipsoid, EllipsoidRanges
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.simulation_report import (
+    SimReportContext,
+    SimReportContextItem,
+    SimReportLinks,
+    SimReportThresholds,
+    SimReportValidationReport,
+    SimReportValidationSummary,
+    SimulationReportBlockDiscretization,
+    SimulationReportDistribution,
+    SimulationReportParameters,
+    SimulationReportResult,
+    SimulationReportResultModel,
+    SimulationReportRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+VARIOGRAM_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200.0, semi_major=150.0, minor=100.0)),
+        max_samples=20,
+    )
+
+
+def _params(**kwargs) -> SimulationReportParameters:
+    defaults = dict(
+        simulation_source=POINTSET_URL,
+        source_attribute="locations.attributes[0]",
+        simulation_target=GRID_URL,
+        point_simulations="cell_attributes[0]",
+        point_simulations_normal_score="cell_attributes[1]",
+        block_simulations="cell_attributes[2]",
+        block_simulations_normal_score="cell_attributes[3]",
+        variogram_model=VARIOGRAM_URL,
+        neighborhood=_search(),
+        number_of_simulations=50,
+        random_seed=38239342,
+    )
+    defaults.update(kwargs)
+    return SimulationReportParameters(**defaults)
+
+
+def _dump(params: SimulationReportParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> SimulationReportResultModel:
+    return SimulationReportResultModel(
+        validation_summary=SimReportValidationSummary(
+            reference_mean=2.345,
+            mean=2.350,
+        ),
+        validation_report=SimReportValidationReport(
+            reference="https://example.com/report.html",
+        ),
+        links=SimReportLinks(
+            dashboard="https://example.com/dashboard",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(SimulationReportParameters)
+        self.assertIs(runner_cls, SimulationReportRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(SimulationReportRunner.topic, "geostatistics")
+        self.assertEqual(SimulationReportRunner.task, "simulation-report")
+
+    def test_runner_types(self):
+        self.assertIs(SimulationReportRunner.params_type, SimulationReportParameters)
+        self.assertIs(SimulationReportRunner.result_model_type, SimulationReportResultModel)
+        self.assertIs(SimulationReportRunner.result_type, SimulationReportResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportParametersSerialization(unittest.TestCase):
+    def test_flat_fields(self):
+        d = _dump(_params())
+        self.assertEqual(d["simulation_source"], POINTSET_URL)
+        self.assertEqual(d["source_attribute"], "locations.attributes[0]")
+        self.assertEqual(d["simulation_target"], GRID_URL)
+        self.assertEqual(d["point_simulations"], "cell_attributes[0]")
+        self.assertEqual(d["point_simulations_normal_score"], "cell_attributes[1]")
+        self.assertEqual(d["block_simulations"], "cell_attributes[2]")
+        self.assertEqual(d["block_simulations_normal_score"], "cell_attributes[3]")
+        self.assertEqual(d["variogram_model"], VARIOGRAM_URL)
+
+    def test_neighborhood(self):
+        d = _dump(_params())
+        self.assertIn("ellipsoid", d["neighborhood"])
+        self.assertEqual(d["neighborhood"]["max_samples"], 20)
+
+    def test_block_discretization_defaults(self):
+        d = _dump(_params())
+        self.assertEqual(d["block_discretization"]["nx"], 1)
+        self.assertEqual(d["block_discretization"]["ny"], 1)
+        self.assertEqual(d["block_discretization"]["nz"], 1)
+
+    def test_block_discretization_custom(self):
+        d = _dump(_params(
+            block_discretization=SimulationReportBlockDiscretization(nx=3, ny=3, nz=3)
+        ))
+        self.assertEqual(d["block_discretization"]["nx"], 3)
+
+    def test_number_of_simulations(self):
+        d = _dump(_params())
+        self.assertEqual(d["number_of_simulations"], 50)
+
+    def test_kriging_method_default(self):
+        d = _dump(_params())
+        self.assertEqual(d["kriging_method"], "simple")
+
+    def test_number_of_lines_default(self):
+        d = _dump(_params())
+        self.assertEqual(d["number_of_lines"], 500)
+
+    def test_distribution_optional(self):
+        d = _dump(_params())
+        self.assertNotIn("distribution", d)
+
+    def test_distribution_with_weights(self):
+        d = _dump(_params(
+            distribution=SimulationReportDistribution(weights="declustering_weights")
+        ))
+        self.assertEqual(d["distribution"]["weights"], "declustering_weights")
+
+    def test_report_context(self):
+        d = _dump(_params(
+            report_context=SimReportContext(
+                title="Test Report",
+                details=[SimReportContextItem(label="Variable", value="Au")],
+            )
+        ))
+        self.assertEqual(d["report_context"]["title"], "Test Report")
+        self.assertEqual(d["report_context"]["details"][0]["label"], "Variable")
+
+    def test_report_mean_thresholds(self):
+        d = _dump(_params(
+            report_mean_thresholds=SimReportThresholds(acceptable=0.05, marginal=0.10)
+        ))
+        self.assertAlmostEqual(d["report_mean_thresholds"]["acceptable"], 0.05)
+        self.assertAlmostEqual(d["report_mean_thresholds"]["marginal"], 0.10)
+
+    def test_none_optional_fields_excluded(self):
+        d = _dump(_params())
+        self.assertNotIn("distribution", d)
+        self.assertNotIn("report_context", d)
+        self.assertNotIn("report_mean_thresholds", d)
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportValidation(unittest.TestCase):
+    def test_block_discretization_min(self):
+        with self.assertRaises(Exception):
+            SimulationReportBlockDiscretization(nx=0, ny=1, nz=1)
+
+    def test_block_discretization_max(self):
+        with self.assertRaises(Exception):
+            SimulationReportBlockDiscretization(nx=10, ny=1, nz=1)
+
+    def test_number_of_simulations_min(self):
+        with self.assertRaises(Exception):
+            _params(number_of_simulations=0)
+
+
+# ---------------------------------------------------------------------------
+# Result model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportResultModel(unittest.TestCase):
+    def test_result_model_validate(self):
+        data = {
+            "validation_summary": {"reference_mean": 1.0, "mean": 1.1},
+            "validation_report": {"reference": "https://example.com/report"},
+            "links": {"dashboard": "https://example.com/dash"},
+        }
+        model = SimulationReportResultModel.model_validate(data)
+        self.assertIsNotNone(model.validation_summary)
+        self.assertAlmostEqual(model.validation_summary.reference_mean, 1.0)
+
+    def test_result_model_minimal(self):
+        model = SimulationReportResultModel.model_validate({})
+        self.assertIsNone(model.validation_summary)
+        self.assertIsNone(model.validation_report)
+        self.assertIsNone(model.links)
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportResult(unittest.TestCase):
+    def _make_result(self) -> SimulationReportResult:
+        return SimulationReportResult(MagicMock(), _make_result_model())
+
+    def test_validation_summary(self):
+        r = self._make_result()
+        self.assertAlmostEqual(r.validation_summary.reference_mean, 2.345)
+        self.assertAlmostEqual(r.validation_summary.mean, 2.350)
+
+    def test_report_reference(self):
+        self.assertEqual(
+            self._make_result().report_reference,
+            "https://example.com/report.html",
+        )
+
+    def test_dashboard_url(self):
+        self.assertEqual(
+            self._make_result().dashboard_url,
+            "https://example.com/dashboard",
+        )
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Simulation Report", s)
+        self.assertIn("2.345", s)
+
+    def test_no_summary(self):
+        model = SimulationReportResultModel()
+        r = SimulationReportResult(MagicMock(), model)
+        self.assertIsNone(r.validation_summary)
+        self.assertIsNone(r.report_reference)
+        self.assertIsNone(r.dashboard_url)
+
+
+# ---------------------------------------------------------------------------
+# Runner behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        connector = MagicMock()
+        context = MagicMock()
+        context.get_connector.return_value = connector
+        context.get_org_id.return_value = "test-org-id"
+        return context
+
+    def _make_job(self):
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+        return job
+
+    async def test_runner_submits_with_correct_topic_and_task(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            result = await SimulationReportRunner(context, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "simulation-report")
+        self.assertIsInstance(result, SimulationReportResult)
+
+    async def test_runner_preview_defaults_false(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            await SimulationReportRunner(context, params)
+
+        _, kwargs = mock_submit.call_args
+        self.assertFalse(kwargs.get("preview", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **simulation-report** geostatistics compute task (`evo.compute.tasks.simulation_report`).

### Changes
- Add `SimulationReportParameters` model with full type coverage (report context, thresholds, etc.)
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.simulation_report import SimulationReportParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes