### PR TITLE
Add simulation-report compute task SDK client

### DIFF
--- a/code-samples/pyproject.toml
+++ b/code-samples/pyproject.toml
@@ -5,8 +5,9 @@ description = "Code samples for the Seequent Evo Python SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "evo-compute>=0.0.3",
     "evo-schemas>=2025.12.15",
-    "evo-sdk>=0.2.1",
+    "evo-sdk>=0.2.2",
     "geosoft>=2025.1.1 ; sys_platform == 'win32' and python_version < '3.14'",
     "PyJWT",
     "matplotlib>=3.10.8",

--- a/code-samples/uv.lock
+++ b/code-samples/uv.lock
@@ -868,9 +868,10 @@ name = "evo-code-samples"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
+    { name = "evo-compute" },
     { name = "evo-schemas" },
     { name = "evo-sdk" },
-    { name = "geosoft", marker = "sys_platform == 'win32'" },
+    { name = "geosoft", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
     { name = "matplotlib" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, extra = ["excel"], marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["excel"], marker = "python_full_version >= '3.11'" },
@@ -897,9 +898,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "evo-compute", specifier = ">=0.0.3" },
     { name = "evo-schemas", specifier = ">=2025.12.15" },
-    { name = "evo-sdk", specifier = ">=0.2.1" },
-    { name = "geosoft", marker = "sys_platform == 'win32'", specifier = ">=2025.1.1" },
+    { name = "evo-sdk", specifier = ">=0.2.2" },
+    { name = "geosoft", marker = "python_full_version < '3.14' and sys_platform == 'win32'", specifier = ">=2025.1.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "pandas", extras = ["excel"], specifier = ">=2.2.3" },
     { name = "plotly", specifier = ">=5.18.0" },
@@ -946,7 +948,7 @@ notebooks = [
 
 [[package]]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "evo-blockmodels", extra = ["utils"] },
@@ -955,9 +957,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/db/74af15545151b23e4ab133dd4a05bca1a7dc2e052d654f3791590b7fbf79/evo_compute-0.0.2.tar.gz", hash = "sha256:2c445333f4becb0c69253e2423f825ef14ab3e3f366a2a483d9c223c245f306a", size = 24270, upload-time = "2026-03-08T21:49:44.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/4cebd50943e9b6de03de015d96a95a3d938e7365b1f642ecb825d2282768/evo_compute-0.0.3.tar.gz", hash = "sha256:528674b45a79e832f7e53b348276ceca38c9ab805279461a3d0eef1d87ff264e", size = 26346, upload-time = "2026-05-19T21:19:11.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/93/2ba09e0d2d94ec2f38f0f7480242e66dbf7e9f9e8002bc9e9c75813b3583/evo_compute-0.0.2-py3-none-any.whl", hash = "sha256:021250b8195d4d285b716568c3f85d32331eb12e4c499bd1ba0093ed0f2ff22e", size = 38015, upload-time = "2026-03-08T21:49:43.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/07/80183fa6a3b065bf0fd9fcfe4caffa4068fe8e1b35027ad967f3485c04d3/evo_compute-0.0.3-py3-none-any.whl", hash = "sha256:7fa421772e8bb5d67086e69215f90fe0480048b5823be88a0fc3bfb956efb20a", size = 44768, upload-time = "2026-05-19T21:19:10.156Z" },
 ]
 
 [package.optional-dependencies]
@@ -1035,11 +1037,11 @@ wheels = [
 
 [[package]]
 name = "evo-sdk"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
-    { name = "evo-blockmodels", extra = ["aiohttp", "notebooks"] },
+    { name = "evo-blockmodels", extra = ["aiohttp", "notebooks", "utils"] },
     { name = "evo-colormaps", extra = ["aiohttp", "notebooks"] },
     { name = "evo-compute", extra = ["aiohttp", "notebooks"] },
     { name = "evo-files", extra = ["aiohttp", "notebooks"] },
@@ -1049,9 +1051,9 @@ dependencies = [
     { name = "jupyter" },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/aa/22db2c6480600c9ade42d1bab71cf6899a78cbfdf5dd445a3e4c25445c9e/evo_sdk-0.2.1.tar.gz", hash = "sha256:31824cd16f668f1f6bae3051ac7d76df4b618724b1a4728b6f08a9e72cb0ee20", size = 632339, upload-time = "2026-03-11T21:55:50.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/5a/5a5d3be21e3a7e95d548c0260de2e1858d7249dd8f60688411642ada6b94/evo_sdk-0.2.2.tar.gz", hash = "sha256:f4e0aba157ad3486ccd753643181b16dbde0ee9fa8c8f1fdecd027d009d398f3", size = 635099, upload-time = "2026-04-24T23:22:20.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/8a/5e6c42cb97074748424a7b580e21611d54bf469d4cc2b2747a54c8542759/evo_sdk-0.2.1-py3-none-any.whl", hash = "sha256:e20bc2e913ad95c7c1ebbeda7a8b657fc01513743d7c0eed1d32356e116dcb69", size = 1149914, upload-time = "2026-03-11T21:55:48.762Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/20/6fe31e7b733b625f114e31db5d7686f739ff2fdd948fb4aff90dd7c74068/evo_sdk-0.2.2-py3-none-any.whl", hash = "sha256:9fc6ec59bee77a2adabb269cd73c45f843584413685737f3f7d0dbd4f86daeb1", size = 1154749, upload-time = "2026-04-24T23:22:18.989Z" },
 ]
 
 [[package]]
@@ -1329,12 +1331,12 @@ name = "geosoft"
 version = "2025.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jdcal", marker = "python_full_version < '3.11' or sys_platform == 'win32'" },
+    { name = "jdcal", marker = "(python_full_version < '3.11' and sys_platform != 'win32') or (python_full_version < '3.14' and sys_platform == 'win32')" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "requests", marker = "python_full_version < '3.11' or sys_platform == 'win32'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform != 'win32') or (python_full_version < '3.14' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/68/b99eca4f320541239f7ef9412c2bf510c5d3977fbce11eec206a271cef84/geosoft-2025.2.0-cp310-none-win_amd64.whl", hash = "sha256:509448451b668fddce604eac683d73b5cd6beb02bbba18dfedc0926698603ec1", size = 6373109, upload-time = "2025-12-15T18:34:30.634Z" },

--- a/mkdocs/site/packages/evo-blockmodels/BlockModelAPIClient.html
+++ b/mkdocs/site/packages/evo-blockmodels/BlockModelAPIClient.html
@@ -936,6 +936,7 @@ until all entries are retrieved. The <code>page_limit</code> is clamped to the s
     <span class="n">initial_data</span><span class="p">:</span> <span class="n">Table</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
     <span class="n">units</span><span class="p">:</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
     <span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+    <span class="n">fill_subblocks</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
 <span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">tuple</span><span class="p">[</span><span class="n">BlockModel</span><span class="p">,</span> <span class="n">Version</span><span class="p">]</span>
 </code></pre></div>
 
@@ -1105,6 +1106,22 @@ returning. This then returns both the block model and the initial block model ve
             </td>
             <td>
                   <code>None</code>
+            </td>
+          </tr>
+          <tr class="doc-section-item">
+            <td>
+                <code>fill_subblocks</code>
+            </td>
+            <td>
+                  <code><span title="bool">bool</span></code>
+            </td>
+            <td>
+              <div class="doc-md-description">
+                <p>Sets the default fill_subblocks behaviour for this block model. If <code>True</code>, updates to a fully sub-blocked model with <code>update_type</code>=<code>merge</code> and <code>geometry_change</code>=<code>True</code> will fill any missing sub-blocks with data from the parent block. Defaults to <code>False</code>.</p>
+              </div>
+            </td>
+            <td>
+                  <code>False</code>
             </td>
           </tr>
       </tbody>
@@ -1618,6 +1635,7 @@ returning. This then returns both the block model and the initial block model ve
     <span class="n">delete_columns</span><span class="p">:</span> <span class="nb">set</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
     <span class="n">units</span><span class="p">:</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
     <span class="n">geometry_change</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
+    <span class="n">fill_subblocks</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Version</span>
 </code></pre></div>
 
@@ -1752,6 +1770,22 @@ If <code>False</code>, the geometry of the sub-blocked model does not change, bu
             </td>
             <td>
                   <code>False</code>
+            </td>
+          </tr>
+          <tr class="doc-section-item">
+            <td>
+                <code>fill_subblocks</code>
+            </td>
+            <td>
+                  <code><span title="bool">bool</span> | None</code>
+            </td>
+            <td>
+              <div class="doc-md-description">
+                <p>If <code>True</code>, any missing sub-blocks will be filled with data from the parent block. Only applicable for fully sub-blocked models when <code>geometry_change</code> is <code>True</code>. If <code>None</code> (the default), the block model's own <code>fill_subblocks</code> setting is used.</p>
+              </div>
+            </td>
+            <td>
+                  <code>None</code>
             </td>
           </tr>
       </tbody>

--- a/mkdocs/site/packages/evo-compute/typed-objects/search/SearchNeighborhood.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/search/SearchNeighborhood.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../source-target/AnySourceAttribute.html" class="nav-link">
+                                <a rel="next" href="../simulation-report/SimReportContext.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/source-target/AnySourceAttribute.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/source-target/AnySourceAttribute.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../search/SearchNeighborhood.html" class="nav-link">
+                                <a rel="prev" href="../simulation-report/SimulationReportRunner.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -31,6 +31,7 @@ from . import break_ties as _break_ties_module  # noqa: F401
 from . import kriging as _kriging_module  # noqa: F401
 from . import location_wise as _location_wise_module  # noqa: F401
 from . import normal_score as _normal_score_module  # noqa: F401
+from . import simulation_report as _simulation_report_module  # noqa: F401
 from .break_ties import BreakTiesResult
 from .kriging import (
     BlockDiscretisation,

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/simulation_report.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/simulation_report.py
@@ -1,0 +1,330 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Simulation report compute task client.
+
+This module provides typed dataclass models and convenience functions for running
+the Simulation Report task (geostatistics/simulation-report).
+
+Generates a validation report for a conditional turning-band simulation,
+including variogram reproduction statistics, summary metrics, and an
+optional interactive dashboard.
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood
+    >>> from evo.compute.tasks.geostatistics.simulation_report import (
+    ...     SimulationReportParameters,
+    ...     SimulationReportBlockDiscretization,
+    ... )
+    >>>
+    >>> params = SimulationReportParameters(
+    ...     simulation_source=pointset_url,
+    ...     source_attribute="locations.attributes[0]",
+    ...     simulation_target=grid_url,
+    ...     point_simulations="cell_attributes[0]",
+    ...     point_simulations_normal_score="cell_attributes[1]",
+    ...     block_simulations="cell_attributes[2]",
+    ...     block_simulations_normal_score="cell_attributes[3]",
+    ...     variogram_model=variogram_url,
+    ...     neighborhood=SearchNeighborhood(...),
+    ...     block_discretization=SimulationReportBlockDiscretization(nx=2, ny=2, nz=2),
+    ...     number_of_simulations=50,
+    ...     random_seed=38239342,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from evo.common import IContext
+from pydantic import BaseModel, Field
+
+from ..common import (
+    GeoscienceObjectReference,
+    SearchNeighborhood,
+)
+from ..common.runner import TaskRunner
+
+__all__ = [
+    "SimReportContext",
+    "SimReportContextItem",
+    "SimReportThresholds",
+    "SimulationReportBlockDiscretization",
+    "SimulationReportDistribution",
+    "SimulationReportParameters",
+    "SimulationReportResult",
+    "SimulationReportResultModel",
+    "SimulationReportRunner",
+]
+
+
+# =============================================================================
+# Supporting Types
+# =============================================================================
+
+
+class SimulationReportBlockDiscretization(BaseModel):
+    """Sub-block discretization for support correction.
+
+    Controls how each block is subdivided for point-to-block variance correction.
+    Each dimension must be between 1 and 9 inclusive.
+    """
+
+    nx: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the X axis."""
+
+    ny: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the Y axis."""
+
+    nz: int = Field(1, ge=1, le=9)
+    """Number of sub-blocks along the Z axis."""
+
+
+class SimulationReportDistribution(BaseModel):
+    """Optional distribution settings for the simulation report.
+
+    When provided, the report includes distribution-related validation.
+    """
+
+    tail_extrapolation: None = None
+    """Reserved for future tail-extrapolation options."""
+
+    weights: str | None = None
+    """Optional attribute expression for sample weights."""
+
+
+class SimReportContextItem(BaseModel):
+    """Single key-value detail for a simulation report."""
+
+    label: str
+    """Display label for this detail."""
+
+    value: str
+    """Display value for this detail."""
+
+
+class SimReportContext(BaseModel):
+    """Report context metadata.
+
+    Adds a title and descriptive details to the generated validation report.
+    """
+
+    title: str
+    """Title for the validation report."""
+
+    details: list[SimReportContextItem] = Field(default_factory=list)
+    """Key-value details to include in the report header."""
+
+
+class SimReportThresholds(BaseModel):
+    """Acceptable/marginal thresholds for mean validation.
+
+    Used to classify the difference between reference mean and simulation mean.
+    """
+
+    acceptable: float = Field(ge=0.0)
+    """Maximum difference considered acceptable."""
+
+    marginal: float = Field(ge=0.0)
+    """Maximum difference considered marginal (between acceptable and failing)."""
+
+
+# =============================================================================
+# Simulation Report Parameters
+# =============================================================================
+
+
+class SimulationReportParameters(BaseModel):
+    """Parameters for the simulation-report compute task.
+
+    All simulation data references use flat string fields (object URLs and
+    attribute expressions) rather than nested Source/Target objects.
+
+    Example:
+        >>> params = SimulationReportParameters(
+        ...     simulation_source=pointset_url,
+        ...     source_attribute="locations.attributes[0]",
+        ...     simulation_target=grid_url,
+        ...     point_simulations="cell_attributes[0]",
+        ...     point_simulations_normal_score="cell_attributes[1]",
+        ...     block_simulations="cell_attributes[2]",
+        ...     block_simulations_normal_score="cell_attributes[3]",
+        ...     variogram_model=variogram_url,
+        ...     neighborhood=SearchNeighborhood(...),
+        ...     number_of_simulations=50,
+        ...     random_seed=38239342,
+        ... )
+    """
+
+    simulation_source: GeoscienceObjectReference
+    """Reference URL to the source geoscience object (typically a pointset)."""
+
+    source_attribute: str
+    """Attribute expression on the source object (e.g. ``"locations.attributes[0]"``)."""
+
+    simulation_target: GeoscienceObjectReference
+    """Reference URL to the target geoscience object (typically a block model)."""
+
+    point_simulations: str
+    """Attribute expression for point simulations on the target."""
+
+    point_simulations_normal_score: str
+    """Attribute expression for point simulation normal scores on the target."""
+
+    block_simulations: str
+    """Attribute expression for block simulations on the target."""
+
+    block_simulations_normal_score: str
+    """Attribute expression for block simulation normal scores on the target."""
+
+    variogram_model: GeoscienceObjectReference
+    """Reference URL to the variogram model object."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighborhood parameters for kriging within the report."""
+
+    block_discretization: SimulationReportBlockDiscretization = Field(
+        default_factory=SimulationReportBlockDiscretization
+    )
+    """Sub-block discretization for support correction."""
+
+    distribution: SimulationReportDistribution | None = None
+    """Optional distribution settings."""
+
+    number_of_simulations: int = Field(ge=1)
+    """Number of simulation realizations to validate."""
+
+    random_seed: int = 38239342
+    """Seed for the random number generator."""
+
+    kriging_method: Literal["simple", "ordinary"] = "simple"
+    """Kriging method used in the simulation."""
+
+    number_of_lines: int = Field(500, ge=1)
+    """Number of turning-band lines."""
+
+    report_context: SimReportContext | None = None
+    """Optional report context metadata."""
+
+    report_mean_thresholds: SimReportThresholds | None = None
+    """Optional thresholds for mean comparison validation."""
+
+
+# =============================================================================
+# Simulation Report Result Types
+# =============================================================================
+
+
+class SimReportValidationSummary(BaseModel):
+    """Validation summary from the simulation report."""
+
+    reference_mean: float
+    """Mean of the reference (source) data."""
+
+    mean: float
+    """Mean of the simulated data."""
+
+
+class SimReportValidationReport(BaseModel):
+    """Reference to the generated validation report file."""
+
+    reference: str
+    """URL to the generated report file."""
+
+
+class SimReportLinks(BaseModel):
+    """Links associated with the simulation report result."""
+
+    dashboard: str | None = None
+    """URL to an interactive dashboard (if generated)."""
+
+
+class SimulationReportResultModel(BaseModel):
+    """Pydantic model for the raw simulation-report task result."""
+
+    validation_summary: SimReportValidationSummary | None = None
+    """Summary comparing reference and simulated means."""
+
+    validation_report: SimReportValidationReport | None = None
+    """Reference to the generated validation report."""
+
+    links: SimReportLinks | None = None
+    """Links to additional resources like dashboards."""
+
+
+class SimulationReportResult:
+    """Result of a simulation-report task.
+
+    Provides access to validation summary, report reference, and dashboard link.
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Simulation Report"
+
+    def __init__(self, context: IContext, model: SimulationReportResultModel) -> None:
+        self._validation_summary = model.validation_summary
+        self._validation_report = model.validation_report
+        self._links = model.links
+        self._context = context
+
+    @property
+    def validation_summary(self) -> SimReportValidationSummary | None:
+        """Validation summary comparing reference and simulated means."""
+        return self._validation_summary
+
+    @property
+    def report_reference(self) -> str | None:
+        """URL to the generated validation report file."""
+        if self._validation_report:
+            return self._validation_report.reference
+        return None
+
+    @property
+    def dashboard_url(self) -> str | None:
+        """URL to the interactive dashboard (if available)."""
+        if self._links:
+            return self._links.dashboard
+        return None
+
+    def __str__(self) -> str:
+        """String representation."""
+        lines = [f"✓ {self.TASK_DISPLAY_NAME} Result"]
+        if self._validation_summary:
+            lines.append(f"  Ref mean:   {self._validation_summary.reference_mean:.4f}")
+            lines.append(f"  Sim mean:   {self._validation_summary.mean:.4f}")
+        if self._validation_report:
+            lines.append(f"  Report:     {self._validation_report.reference}")
+        if self._links and self._links.dashboard:
+            lines.append(f"  Dashboard:  {self._links.dashboard}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class SimulationReportRunner(
+    TaskRunner[SimulationReportParameters, SimulationReportResultModel, SimulationReportResult],
+    topic="geostatistics",
+    task="simulation-report",
+):
+    """Runner for simulation-report compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await SimulationReportRunner(context, params)
+    """
+
+    async def _get_result(self, raw_result: SimulationReportResultModel) -> SimulationReportResult:
+        return SimulationReportResult(self._context, raw_result)

--- a/packages/evo-compute/tests/geostatistics/test_simulation_report_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_simulation_report_tasks.py
@@ -1,0 +1,321 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for simulation-report task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import Ellipsoid, EllipsoidRanges
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.simulation_report import (
+    SimReportContext,
+    SimReportContextItem,
+    SimReportLinks,
+    SimReportThresholds,
+    SimReportValidationReport,
+    SimReportValidationSummary,
+    SimulationReportBlockDiscretization,
+    SimulationReportDistribution,
+    SimulationReportParameters,
+    SimulationReportResult,
+    SimulationReportResultModel,
+    SimulationReportRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+VARIOGRAM_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200.0, semi_major=150.0, minor=100.0)),
+        max_samples=20,
+    )
+
+
+def _params(**kwargs) -> SimulationReportParameters:
+    defaults = dict(
+        simulation_source=POINTSET_URL,
+        source_attribute="locations.attributes[0]",
+        simulation_target=GRID_URL,
+        point_simulations="cell_attributes[0]",
+        point_simulations_normal_score="cell_attributes[1]",
+        block_simulations="cell_attributes[2]",
+        block_simulations_normal_score="cell_attributes[3]",
+        variogram_model=VARIOGRAM_URL,
+        neighborhood=_search(),
+        number_of_simulations=50,
+        random_seed=38239342,
+    )
+    defaults.update(kwargs)
+    return SimulationReportParameters(**defaults)
+
+
+def _dump(params: SimulationReportParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> SimulationReportResultModel:
+    return SimulationReportResultModel(
+        validation_summary=SimReportValidationSummary(
+            reference_mean=2.345,
+            mean=2.350,
+        ),
+        validation_report=SimReportValidationReport(
+            reference="https://example.com/report.html",
+        ),
+        links=SimReportLinks(
+            dashboard="https://example.com/dashboard",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(SimulationReportParameters)
+        self.assertIs(runner_cls, SimulationReportRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(SimulationReportRunner.topic, "geostatistics")
+        self.assertEqual(SimulationReportRunner.task, "simulation-report")
+
+    def test_runner_types(self):
+        self.assertIs(SimulationReportRunner.params_type, SimulationReportParameters)
+        self.assertIs(SimulationReportRunner.result_model_type, SimulationReportResultModel)
+        self.assertIs(SimulationReportRunner.result_type, SimulationReportResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportParametersSerialization(unittest.TestCase):
+    def test_flat_fields(self):
+        d = _dump(_params())
+        self.assertEqual(d["simulation_source"], POINTSET_URL)
+        self.assertEqual(d["source_attribute"], "locations.attributes[0]")
+        self.assertEqual(d["simulation_target"], GRID_URL)
+        self.assertEqual(d["point_simulations"], "cell_attributes[0]")
+        self.assertEqual(d["point_simulations_normal_score"], "cell_attributes[1]")
+        self.assertEqual(d["block_simulations"], "cell_attributes[2]")
+        self.assertEqual(d["block_simulations_normal_score"], "cell_attributes[3]")
+        self.assertEqual(d["variogram_model"], VARIOGRAM_URL)
+
+    def test_neighborhood(self):
+        d = _dump(_params())
+        self.assertIn("ellipsoid", d["neighborhood"])
+        self.assertEqual(d["neighborhood"]["max_samples"], 20)
+
+    def test_block_discretization_defaults(self):
+        d = _dump(_params())
+        self.assertEqual(d["block_discretization"]["nx"], 1)
+        self.assertEqual(d["block_discretization"]["ny"], 1)
+        self.assertEqual(d["block_discretization"]["nz"], 1)
+
+    def test_block_discretization_custom(self):
+        d = _dump(_params(block_discretization=SimulationReportBlockDiscretization(nx=3, ny=3, nz=3)))
+        self.assertEqual(d["block_discretization"]["nx"], 3)
+
+    def test_number_of_simulations(self):
+        d = _dump(_params())
+        self.assertEqual(d["number_of_simulations"], 50)
+
+    def test_kriging_method_default(self):
+        d = _dump(_params())
+        self.assertEqual(d["kriging_method"], "simple")
+
+    def test_number_of_lines_default(self):
+        d = _dump(_params())
+        self.assertEqual(d["number_of_lines"], 500)
+
+    def test_distribution_optional(self):
+        d = _dump(_params())
+        self.assertNotIn("distribution", d)
+
+    def test_distribution_with_weights(self):
+        d = _dump(_params(distribution=SimulationReportDistribution(weights="declustering_weights")))
+        self.assertEqual(d["distribution"]["weights"], "declustering_weights")
+
+    def test_report_context(self):
+        d = _dump(
+            _params(
+                report_context=SimReportContext(
+                    title="Test Report",
+                    details=[SimReportContextItem(label="Variable", value="Au")],
+                )
+            )
+        )
+        self.assertEqual(d["report_context"]["title"], "Test Report")
+        self.assertEqual(d["report_context"]["details"][0]["label"], "Variable")
+
+    def test_report_mean_thresholds(self):
+        d = _dump(_params(report_mean_thresholds=SimReportThresholds(acceptable=0.05, marginal=0.10)))
+        self.assertAlmostEqual(d["report_mean_thresholds"]["acceptable"], 0.05)
+        self.assertAlmostEqual(d["report_mean_thresholds"]["marginal"], 0.10)
+
+    def test_none_optional_fields_excluded(self):
+        d = _dump(_params())
+        self.assertNotIn("distribution", d)
+        self.assertNotIn("report_context", d)
+        self.assertNotIn("report_mean_thresholds", d)
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportValidation(unittest.TestCase):
+    def test_block_discretization_min(self):
+        with self.assertRaises(Exception):
+            SimulationReportBlockDiscretization(nx=0, ny=1, nz=1)
+
+    def test_block_discretization_max(self):
+        with self.assertRaises(Exception):
+            SimulationReportBlockDiscretization(nx=10, ny=1, nz=1)
+
+    def test_number_of_simulations_min(self):
+        with self.assertRaises(Exception):
+            _params(number_of_simulations=0)
+
+
+# ---------------------------------------------------------------------------
+# Result model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportResultModel(unittest.TestCase):
+    def test_result_model_validate(self):
+        data = {
+            "validation_summary": {"reference_mean": 1.0, "mean": 1.1},
+            "validation_report": {"reference": "https://example.com/report"},
+            "links": {"dashboard": "https://example.com/dash"},
+        }
+        model = SimulationReportResultModel.model_validate(data)
+        self.assertIsNotNone(model.validation_summary)
+        self.assertAlmostEqual(model.validation_summary.reference_mean, 1.0)
+
+    def test_result_model_minimal(self):
+        model = SimulationReportResultModel.model_validate({})
+        self.assertIsNone(model.validation_summary)
+        self.assertIsNone(model.validation_report)
+        self.assertIsNone(model.links)
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportResult(unittest.TestCase):
+    def _make_result(self) -> SimulationReportResult:
+        return SimulationReportResult(MagicMock(), _make_result_model())
+
+    def test_validation_summary(self):
+        r = self._make_result()
+        self.assertAlmostEqual(r.validation_summary.reference_mean, 2.345)
+        self.assertAlmostEqual(r.validation_summary.mean, 2.350)
+
+    def test_report_reference(self):
+        self.assertEqual(
+            self._make_result().report_reference,
+            "https://example.com/report.html",
+        )
+
+    def test_dashboard_url(self):
+        self.assertEqual(
+            self._make_result().dashboard_url,
+            "https://example.com/dashboard",
+        )
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Simulation Report", s)
+        self.assertIn("2.345", s)
+
+    def test_no_summary(self):
+        model = SimulationReportResultModel()
+        r = SimulationReportResult(MagicMock(), model)
+        self.assertIsNone(r.validation_summary)
+        self.assertIsNone(r.report_reference)
+        self.assertIsNone(r.dashboard_url)
+
+
+# ---------------------------------------------------------------------------
+# Runner behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationReportRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        connector = MagicMock()
+        context = MagicMock()
+        context.get_connector.return_value = connector
+        context.get_org_id.return_value = "test-org-id"
+        return context
+
+    def _make_job(self):
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+        return job
+
+    async def test_runner_submits_with_correct_topic_and_task(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            result = await SimulationReportRunner(context, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "simulation-report")
+        self.assertIsInstance(result, SimulationReportResult)
+
+    async def test_runner_preview_defaults_false(self):
+        context = self._make_context()
+        params = _params()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            await SimulationReportRunner(context, params)
+
+        _, kwargs = mock_submit.call_args
+        self.assertFalse(kwargs.get("preview", True))


### PR DESCRIPTION
## Summary

Adds an SDK client for the **simulation-report** geostatistics compute task (`geostatistics/simulation-report`), and fixes the notebook test environment to use `evo-compute>=0.0.3` which includes the geostatistics subpackage.

### Changes

**Commit 1 — `feat: add simulation-report compute task SDK client`**
- New: `simulation_report.py` — `SimulationReportParameters`, `SimulationReportResult`, `SimulationReportRunner`
- New: `test_simulation_report_tasks.py` — comprehensive test suite (registration, serialization, result handling, runner execution)
- Updated: `geostatistics/__init__.py` — import simulation_report module for runner registration

**Commit 2 — `fix: bump evo-compute to 0.0.3 in code-samples`**
- Updated: `code-samples/pyproject.toml` — add explicit `evo-compute>=0.0.3` dependency, bump `evo-sdk>=0.2.2`
- Updated: `code-samples/uv.lock` — regenerated to resolve `evo-compute==0.0.3`

### Notebook test fix

The `running-kriging-compute.ipynb` notebook test was failing with `ModuleNotFoundError: No module named 'evo.compute.tasks.geostatistics'` because `code-samples/uv.lock` resolved `evo-compute==0.0.2` from PyPI, which predates the geostatistics subpackage restructuring (introduced in PR #266, published in v0.0.3). This was a pre-existing issue on `main`.

### How to Test
1. `from evo.compute.tasks.geostatistics.simulation_report import SimulationReportParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated (228 passed)
- [x] All pre-commit hooks pass
- [x] Code has been linted
- [x] Notebook test failure fixed (evo-compute bumped to 0.0.3)
- [ ] No breaking changes