### PR TITLE
Add KNN estimation task SDK client

### DIFF
--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../break-ties/BreakTiesRunner.html" class="nav-link">
+                                <a rel="prev" href="../knn/KNNTarget.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -28,6 +28,7 @@ Example:
 """
 
 from . import break_ties as _break_ties_module  # noqa: F401
+from . import knn as _knn_module  # noqa: F401
 from . import kriging as _kriging_module  # noqa: F401
 from . import location_wise as _location_wise_module  # noqa: F401
 from .break_ties import BreakTiesResult

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/knn.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/knn.py
@@ -1,0 +1,169 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""K-Nearest Neighbors (KNN) estimation compute task client.
+
+Estimates values at target locations using the arithmetic mean of the
+*k*-nearest source samples within a search neighborhood.
+
+.. note::
+
+   This task uses the older ``geostat`` API format with
+   ``object_reference`` / ``object_element`` parameter encoding.
+
+Example:
+    >>> from evo.compute.tasks import run
+    >>> from evo.compute.tasks.geostatistics.knn import KNNParameters, KNNSource, KNNTarget
+    >>>
+    >>> params = KNNParameters(
+    ...     source=KNNSource(
+    ...         object_reference=pointset_url,
+    ...         object_element=[GORefElement(path="/locations/attributes/@name=grade")],
+    ...     ),
+    ...     target=KNNTarget(
+    ...         object_reference=grid_url,
+    ...         object_element=[GORefElement(path="/cell_attributes/@name=knn_grade")],
+    ...     ),
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=20,
+    ...     ),
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from evo.common import IContext
+from pydantic import BaseModel
+
+from ..common import GeoscienceObjectReference, SearchNeighborhood
+from ..common.runner import TaskRunner
+
+__all__ = [
+    "GORefElement",
+    "KNNParameters",
+    "KNNResult",
+    "KNNResultModel",
+    "KNNRunner",
+    "KNNSource",
+    "KNNTarget",
+]
+
+
+# =============================================================================
+# Old-format reference types
+# =============================================================================
+
+
+class GORefElement(BaseModel):
+    """A geoscience object reference element (old API format)."""
+
+    type: Literal["element"] = "element"
+    """Element type discriminator."""
+
+    path: str
+    """Attribute path, e.g. ``/locations/attributes/@name=grade``."""
+
+
+class KNNSource(BaseModel):
+    """Source for the KNN task (old-format geoscience-object-reference)."""
+
+    type: Literal["geoscience-object-reference"] = "geoscience-object-reference"
+    object_reference: GeoscienceObjectReference
+    object_element: list[GORefElement]
+
+
+class KNNTarget(BaseModel):
+    """Target for the KNN task (old-format geoscience-object-reference)."""
+
+    type: Literal["geoscience-object-reference"] = "geoscience-object-reference"
+    object_reference: GeoscienceObjectReference
+    object_element: list[GORefElement]
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class KNNParameters(BaseModel):
+    """Parameters for the KNN estimation task."""
+
+    source: KNNSource
+    """The source object and attribute containing known values."""
+
+    target: KNNTarget
+    """The target object and attribute to create or update with KNN results."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighborhood parameters."""
+
+
+# =============================================================================
+# Result Types
+# =============================================================================
+
+
+class KNNModifiedResult(BaseModel):
+    """Modified geoscience object reference from a KNN result."""
+
+    object_reference: str
+    object_element: list[GORefElement] | None = None
+
+
+class KNNResultModel(BaseModel):
+    """Pydantic model for the raw KNN task result."""
+
+    message: str
+    object_modified: KNNModifiedResult
+
+
+class KNNResult:
+    TASK_DISPLAY_NAME: ClassVar[str] = "KNN Estimation"
+
+    def __init__(self, context: IContext, model: KNNResultModel) -> None:
+        self._result = model.object_modified
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @property
+    def object_reference(self) -> str:
+        """Reference URL to the modified object."""
+        return self._result.object_reference
+
+    def __str__(self) -> str:
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message: {self.message}",
+            f"  Object:  {self.object_reference}",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class KNNRunner(
+    TaskRunner[KNNParameters, KNNResultModel, KNNResult],
+    topic="geostat",
+    task="knn",
+):
+    async def _get_result(self, raw_result: KNNResultModel) -> KNNResult:
+        return KNNResult(self._context, raw_result)

--- a/packages/evo-compute/tests/geostatistics/test_knn_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_knn_tasks.py
@@ -1,0 +1,174 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License")
+
+"""Tests for KNN task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import Ellipsoid, EllipsoidRanges
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.knn import (
+    GORefElement,
+    KNNModifiedResult,
+    KNNParameters,
+    KNNResult,
+    KNNResultModel,
+    KNNRunner,
+    KNNSource,
+    KNNTarget,
+)
+
+# ---------------------------------------------------------------------------
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200, semi_major=150, minor=100)),
+        max_samples=20,
+    )
+
+
+def _params(**kwargs) -> KNNParameters:
+    defaults = dict(
+        source=KNNSource(
+            object_reference=POINTSET_URL,
+            object_element=[GORefElement(path="/locations/attributes/@name=grade")],
+        ),
+        target=KNNTarget(
+            object_reference=GRID_URL,
+            object_element=[GORefElement(path="/cell_attributes/@name=knn_grade")],
+        ),
+        neighborhood=_search(),
+    )
+    defaults.update(kwargs)
+    return KNNParameters(**defaults)
+
+
+def _dump(params: KNNParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> KNNResultModel:
+    return KNNResultModel(
+        message="KNN estimation completed.",
+        object_modified=KNNModifiedResult(
+            object_reference=GRID_URL,
+            object_element=[GORefElement(path="/cell_attributes/@name=knn_grade")],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+class TestKNNRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(KNNParameters)
+        self.assertIs(runner_cls, KNNRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(KNNRunner.topic, "geostat")
+        self.assertEqual(KNNRunner.task, "knn")
+
+    def test_runner_types(self):
+        self.assertIs(KNNRunner.params_type, KNNParameters)
+        self.assertIs(KNNRunner.result_model_type, KNNResultModel)
+        self.assertIs(KNNRunner.result_type, KNNResult)
+
+
+# ---------------------------------------------------------------------------
+class TestGORefElement(unittest.TestCase):
+    def test_defaults(self):
+        e = GORefElement(path="/locations/attributes/@name=grade")
+        self.assertEqual(e.type, "element")
+        self.assertEqual(e.path, "/locations/attributes/@name=grade")
+
+    def test_serialization(self):
+        e = GORefElement(path="/cell_attributes/@name=x")
+        d = e.model_dump(mode="json")
+        self.assertEqual(d["type"], "element")
+        self.assertEqual(d["path"], "/cell_attributes/@name=x")
+
+
+# ---------------------------------------------------------------------------
+class TestKNNParametersSerialization(unittest.TestCase):
+    def test_source_old_format(self):
+        d = _dump(_params())
+        src = d["source"]
+        self.assertEqual(src["type"], "geoscience-object-reference")
+        self.assertEqual(src["object_reference"], POINTSET_URL)
+        self.assertEqual(len(src["object_element"]), 1)
+        self.assertEqual(src["object_element"][0]["type"], "element")
+        self.assertEqual(src["object_element"][0]["path"], "/locations/attributes/@name=grade")
+
+    def test_target_old_format(self):
+        d = _dump(_params())
+        tgt = d["target"]
+        self.assertEqual(tgt["type"], "geoscience-object-reference")
+        self.assertEqual(tgt["object_reference"], GRID_URL)
+        self.assertEqual(tgt["object_element"][0]["path"], "/cell_attributes/@name=knn_grade")
+
+    def test_neighborhood(self):
+        d = _dump(_params())
+        self.assertIn("ellipsoid", d["neighborhood"])
+        self.assertEqual(d["neighborhood"]["max_samples"], 20)
+
+
+# ---------------------------------------------------------------------------
+class TestKNNResult(unittest.TestCase):
+    def _make_result(self) -> KNNResult:
+        return KNNResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("completed", self._make_result().message)
+
+    def test_object_reference(self):
+        self.assertEqual(self._make_result().object_reference, GRID_URL)
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("KNN", s)
+        self.assertIn(GRID_URL, s)
+
+
+# ---------------------------------------------------------------------------
+class TestKNNRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await KNNRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostat")
+        self.assertEqual(kwargs["task"], "knn")
+        self.assertIsInstance(result, KNNResult)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add typed SDK client for the **KNN estimation** geostatistics compute task (`evo.compute.tasks.knn`).

### Changes
- Add `KNNParameters` model with full type coverage
- Register task module in `tasks/__init__.py`
- Add unit tests for parameter construction and serialization

### How to Test
1. `from evo.compute.tasks.knn import KNNParameters`
2. Construct parameters and verify JSON serialization matches the Task API schema

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Unit tests added/updated
- [x] All tests pass
- [x] Code has been linted
- [ ] No breaking changes