### PR TITLE
Add location-wise task & reorganize geostatistics tasks into subpackage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,8 +21,8 @@
 packages/evo-blockmodels/                   @SeequentEvo/blockmodels-maintainers
 packages/evo-colormaps/                     @SeequentEvo/colormaps-maintainers
 packages/evo-compute/                       @SeequentEvo/compute-maintainers
-packages/evo-compute/src/evo/compute/tasks/geostatistics/ @SeequentEvo/geostatistics-maintainers
-packages/evo-compute/tests/geostatistics/    @SeequentEvo/geostatistics-maintainers
+packages/evo-compute/src/evo/compute/tasks/geostatistics/ @SeequentEvo/geostatistics-maintainers @SeequentEvo/compute-maintainers
+packages/evo-compute/tests/geostatistics/    @SeequentEvo/geostatistics-maintainers @SeequentEvo/compute-maintainers
 packages/evo-files/                         @SeequentEvo/files-maintainers
 packages/evo-objects/                       @SeequentEvo/objects-maintainers
 packages/evo-sdk-common/                    @SeequentEvo/python-sdk-common-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,8 @@
 packages/evo-blockmodels/                   @SeequentEvo/blockmodels-maintainers
 packages/evo-colormaps/                     @SeequentEvo/colormaps-maintainers
 packages/evo-compute/                       @SeequentEvo/compute-maintainers
+packages/evo-compute/src/evo/compute/tasks/geostatistics/ @SeequentEvo/geostatistics-maintainers
+packages/evo-compute/tests/geostatistics/    @SeequentEvo/geostatistics-maintainers
 packages/evo-files/                         @SeequentEvo/files-maintainers
 packages/evo-objects/                       @SeequentEvo/objects-maintainers
 packages/evo-sdk-common/                    @SeequentEvo/python-sdk-common-maintainers

--- a/code-samples/geoscience-objects/running-kriging-compute/running-kriging-compute.ipynb
+++ b/code-samples/geoscience-objects/running-kriging-compute/running-kriging-compute.ipynb
@@ -633,7 +633,7 @@
    "outputs": [],
    "source": [
     "from evo.compute.tasks import SearchNeighborhood\n",
-    "from evo.compute.tasks.kriging import KrigingParameters\n",
+    "from evo.compute.tasks.geostatistics.kriging import KrigingParameters\n",
     "\n",
     "# Use the search ellipsoid we created earlier (2x variogram range)\n",
     "params = KrigingParameters(\n",

--- a/mkdocs/docs/packages/evo-compute/index.md
+++ b/mkdocs/docs/packages/evo-compute/index.md
@@ -13,7 +13,7 @@ The `run()` function is the main entry point for executing compute tasks. It sup
 
 ```python
 from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-from evo.compute.tasks.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters
 
 params = KrigingParameters(
     source=pointset.attributes["grade"],
@@ -33,7 +33,7 @@ Run multiple kriging tasks concurrently — for example, estimating different at
 
 ```python
 from evo.compute.tasks import run, SearchNeighborhood
-from evo.compute.tasks.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters
 
 results = await run(manager, [
     KrigingParameters(
@@ -87,7 +87,7 @@ To avoid this:
 
 ```python
 from evo.compute.tasks import run, SearchNeighborhood
-from evo.compute.tasks.kriging import KrigingParameters, RegionFilter
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters, RegionFilter
 
 # Step 1: Run the first task — attribute "kriged_grade" does not exist yet, so it is created
 first_result = await run(manager, KrigingParameters(

--- a/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesParameters.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesParameters.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py)
+::: evo.compute.tasks.geostatistics.break_ties.BreakTiesParameters
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesResult.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesResult.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py)
+::: evo.compute.tasks.geostatistics.break_ties.BreakTiesResult
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesResultModel.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesResultModel.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py)
+::: evo.compute.tasks.geostatistics.break_ties.BreakTiesResultModel
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesRunner.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/break-ties/BreakTiesRunner.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py)
+::: evo.compute.tasks.geostatistics.break_ties.BreakTiesRunner
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.BlockDiscretisation
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.BlockDiscretisation
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingMethod.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingMethod.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.KrigingMethod
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.KrigingMethod
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingParameters.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingParameters.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.KrigingParameters
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.KrigingParameters
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingResult.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingResult.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.KrigingResult
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.KrigingResult
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingResultModel.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingResultModel.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.KrigingResultModel
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.KrigingResultModel
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingRunner.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/KrigingRunner.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.KrigingRunner
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.KrigingRunner
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.OrdinaryKriging
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.OrdinaryKriging
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/RegionFilter.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/RegionFilter.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.RegionFilter
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.RegionFilter
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/kriging/SimpleKriging.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/kriging/SimpleKriging.md
@@ -1,4 +1,4 @@
-[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py)
-::: evo.compute.tasks.kriging.SimpleKriging
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py)
+::: evo.compute.tasks.geostatistics.kriging.SimpleKriging
     options:
       show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseParameters.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseParameters.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseParameters
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseResult.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseResult.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseResult
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseResultModel.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseResultModel.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseResultModel
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseRunner.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseRunner.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseRunner
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseTarget.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseTarget.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseTarget
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseTargetResult.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/LocationWiseTargetResult.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.LocationWiseTargetResult
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/MeanAboveCutoff.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/MeanAboveCutoff.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.MeanAboveCutoff
+    options:
+      show_labels: false

--- a/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/ProbabilityAboveCutoff.md
+++ b/mkdocs/docs/packages/evo-compute/typed-objects/location-wise/ProbabilityAboveCutoff.md
@@ -1,0 +1,4 @@
+[GitHub source](https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py)
+::: evo.compute.tasks.geostatistics.location_wise.ProbabilityAboveCutoff
+    options:
+      show_labels: false

--- a/mkdocs/site/packages/evo-compute/index.html
+++ b/mkdocs/site/packages/evo-compute/index.html
@@ -86,7 +86,7 @@ JobClient provides low-level access to the API, while the <code>run()</code> fun
 <p>The <code>run()</code> function is the main entry point for executing compute tasks. It supports running a single task or multiple tasks concurrently.</p>
 <h3 id="single-task">Single task</h3>
 <pre><code class="language-python">from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-from evo.compute.tasks.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters
 
 params = KrigingParameters(
     source=pointset.attributes[&quot;grade&quot;],
@@ -102,7 +102,7 @@ result = await run(manager, params, preview=True)
 <h3 id="multiple-tasks">Multiple tasks</h3>
 <p>Run multiple kriging tasks concurrently — for example, estimating different attributes or using different parameters:</p>
 <pre><code class="language-python">from evo.compute.tasks import run, SearchNeighborhood
-from evo.compute.tasks.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters
 
 results = await run(manager, [
     KrigingParameters(
@@ -145,7 +145,7 @@ df = await result.to_dataframe()
 <li>Run the <strong>remaining</strong> tasks — now <code>block_model.attributes["kriged_grade"]</code> resolves to the existing attribute and will update it.</li>
 </ol>
 <pre><code class="language-python">from evo.compute.tasks import run, SearchNeighborhood
-from evo.compute.tasks.kriging import KrigingParameters, RegionFilter
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters, RegionFilter
 
 # Step 1: Run the first task — attribute &quot;kriged_grade&quot; does not exist yet, so it is created
 first_result = await run(manager, KrigingParameters(

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.BlockDiscretisation" class="nav-link">BlockDiscretisation</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.BlockDiscretisation" class="nav-link">BlockDiscretisation</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.BlockDiscretisation" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.BlockDiscretisation</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.BlockDiscretisation" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.BlockDiscretisation</span>
 
 
 </h2>
@@ -121,7 +121,7 @@ The default value of 1 in every direction is equivalent to point kriging.</p>
 
 
 
-<h3 id="evo.compute.tasks.kriging.BlockDiscretisation.nx" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.BlockDiscretisation.nx" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">nx</span>
 
 
@@ -141,7 +141,7 @@ The default value of 1 in every direction is equivalent to point kriging.</p>
 
 
 
-<h3 id="evo.compute.tasks.kriging.BlockDiscretisation.ny" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.BlockDiscretisation.ny" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">ny</span>
 
 
@@ -161,7 +161,7 @@ The default value of 1 in every direction is equivalent to point kriging.</p>
 
 
 
-<h3 id="evo.compute.tasks.kriging.BlockDiscretisation.nz" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.BlockDiscretisation.nz" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">nz</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingMethod.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingMethod.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.KrigingMethod" class="nav-link">KrigingMethod</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.KrigingMethod" class="nav-link">KrigingMethod</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.KrigingMethod" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.KrigingMethod</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.KrigingMethod" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.KrigingMethod</span>
 
 
 </h2>
@@ -120,7 +120,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingMethod.ORDINARY" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingMethod.ORDINARY" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">ORDINARY</span>
 
 
@@ -142,7 +142,7 @@
 <div class="doc doc-object doc-function">
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingMethod.simple" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingMethod.simple" class="doc doc-heading">
             <span class="doc doc-object-name doc-function-name">simple</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.KrigingParameters" class="nav-link">KrigingParameters</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.KrigingParameters" class="nav-link">KrigingParameters</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.KrigingParameters" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.KrigingParameters</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.KrigingParameters</span>
 
 
 </h2>
@@ -140,7 +140,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.source" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.source" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">source</span>
 
 
@@ -160,7 +160,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.target" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.target" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">target</span>
 
 
@@ -180,7 +180,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.variogram" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.variogram" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">variogram</span>
 
 
@@ -200,7 +200,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.search" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.search" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">search</span>
 
 
@@ -220,7 +220,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.method" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.method" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">method</span>
 
 
@@ -240,7 +240,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.target_region_filter" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.target_region_filter" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">target_region_filter</span>
 
 
@@ -260,7 +260,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingParameters.block_discretisation" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.block_discretisation" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">block_discretisation</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
@@ -93,7 +93,7 @@
 <p>Defines all inputs needed to run a kriging interpolation task.</p>
 <p>Example:
     &gt;&gt;&gt; from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-    &gt;&gt;&gt; from evo.compute.tasks.kriging import KrigingParameters, RegionFilter
+    &gt;&gt;&gt; from evo.compute.tasks.geostatistics.kriging import KrigingParameters, RegionFilter
     &gt;&gt;&gt;
     &gt;&gt;&gt; params = KrigingParameters(
     ...     source=pointset.attributes["grade"],  # Source attribute

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResult.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResult.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.KrigingResult" class="nav-link">KrigingResult</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.KrigingResult" class="nav-link">KrigingResult</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.KrigingResult" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.KrigingResult</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.KrigingResult" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.KrigingResult</span>
 
 
 </h2>
@@ -111,7 +111,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.message" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.message" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">message</span>
 
 
@@ -131,7 +131,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.target_name" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.target_name" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">target_name</span>
 
 
@@ -151,7 +151,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.target_reference" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.target_reference" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">target_reference</span>
 
 
@@ -171,7 +171,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.attribute_name" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.attribute_name" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">attribute_name</span>
 
 
@@ -191,7 +191,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.schema" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.schema" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">schema</span>
 
 
@@ -215,7 +215,7 @@ raw <code>schema_id</code> string when it cannot be parsed.</p>
 <div class="doc doc-object doc-function">
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.get_target_object" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.get_target_object" class="doc doc-heading">
             <span class="doc doc-object-name doc-function-name">get_target_object</span>
 
 
@@ -244,7 +244,7 @@ raw <code>schema_id</code> string when it cannot be parsed.</p>
 <div class="doc doc-object doc-function">
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.to_dataframe" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.to_dataframe" class="doc doc-heading">
             <span class="doc doc-object-name doc-function-name">to_dataframe</span>
 
 
@@ -277,7 +277,7 @@ the target object and returns its data as a pandas DataFrame.</p>
 <div class="doc doc-object doc-function">
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResult.__str__" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.__str__" class="doc doc-heading">
             <span class="doc doc-object-name doc-function-name">__str__</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResultModel.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResultModel.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.KrigingResultModel" class="nav-link">KrigingResultModel</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.KrigingResultModel" class="nav-link">KrigingResultModel</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.KrigingResultModel" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.KrigingResultModel</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.KrigingResultModel" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.KrigingResultModel</span>
 
 
 </h2>
@@ -117,7 +117,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResultModel.message" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResultModel.message" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">message</span>
 
 
@@ -137,7 +137,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.KrigingResultModel.target" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResultModel.target" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">target</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingRunner.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingRunner.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.KrigingRunner" class="nav-link">KrigingRunner</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.KrigingRunner" class="nav-link">KrigingRunner</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.KrigingRunner" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.KrigingRunner</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.KrigingRunner" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.KrigingRunner</span>
 
 
 </h2>

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.OrdinaryKriging" class="nav-link">OrdinaryKriging</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.OrdinaryKriging" class="nav-link">OrdinaryKriging</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.OrdinaryKriging" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.OrdinaryKriging</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.OrdinaryKriging" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.OrdinaryKriging</span>
 
 
 </h2>
@@ -115,7 +115,7 @@ This is the default kriging method if none is specified.</p>
 
 
 
-<h3 id="evo.compute.tasks.kriging.OrdinaryKriging.type" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.OrdinaryKriging.type" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">type</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/RegionFilter.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/RegionFilter.html
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.RegionFilter" class="nav-link">RegionFilter</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.RegionFilter" class="nav-link">RegionFilter</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.RegionFilter" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.RegionFilter</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.RegionFilter" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.RegionFilter</span>
 
 
 </h2>
@@ -128,7 +128,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.RegionFilter.attribute" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.RegionFilter.attribute" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">attribute</span>
 
 
@@ -148,7 +148,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.RegionFilter.names" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.RegionFilter.names" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">names</span>
 
 
@@ -168,7 +168,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.RegionFilter.values" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.RegionFilter.values" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">values</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/SimpleKriging.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/SimpleKriging.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../results/TaskAttribute.html" class="nav-link">
+                                <a rel="next" href="../location-wise/LocationWiseParameters.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>
@@ -61,7 +61,7 @@
     <div id="toc-collapse" class="navbar-collapse collapse card bg-body-tertiary">
         <ul class="nav flex-column">
             
-            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.kriging.SimpleKriging" class="nav-link">SimpleKriging</a>
+            <li class="nav-item" data-bs-level="2"><a href="#evo.compute.tasks.geostatistics.kriging.SimpleKriging" class="nav-link">SimpleKriging</a>
               <ul class="nav flex-column">
               </ul>
             </li>
@@ -70,7 +70,7 @@
 </div></div>
                     <div class="col-md-9" role="main">
 
-<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/kriging.py">GitHub source</a>
+<p><a href="https://github.com/SeequentEvo/evo-python-sdk/blob/main/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py">GitHub source</a>
 </p>
 
 
@@ -78,8 +78,8 @@
 
 
 
-<h2 id="evo.compute.tasks.kriging.SimpleKriging" class="doc doc-heading">
-            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.kriging.SimpleKriging</span>
+<h2 id="evo.compute.tasks.geostatistics.kriging.SimpleKriging" class="doc doc-heading">
+            <span class="doc doc-object-name doc-class-name">evo.compute.tasks.geostatistics.kriging.SimpleKriging</span>
 
 
 </h2>
@@ -116,7 +116,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.SimpleKriging.type" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.SimpleKriging.type" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">type</span>
 
 
@@ -136,7 +136,7 @@
 
 
 
-<h3 id="evo.compute.tasks.kriging.SimpleKriging.mean" class="doc doc-heading">
+<h3 id="evo.compute.tasks.geostatistics.kriging.SimpleKriging.mean" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">mean</span>
 
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/results/TaskAttribute.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/results/TaskAttribute.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../kriging/SimpleKriging.html" class="nav-link">
+                                <a rel="prev" href="../location-wise/ProbabilityAboveCutoff.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/mkdocs/typed_modules.txt
+++ b/mkdocs/typed_modules.txt
@@ -1,5 +1,5 @@
 packages.evo-objects.src.evo.objects.typed
 packages.evo-blockmodels.src.evo.blockmodels.typed
-packages.evo-compute.src.evo.compute.tasks
+packages.evo-compute.src.evo.compute.tasks.geostatistics
 packages.evo-compute.src.evo.compute.tasks.common
 

--- a/packages/evo-compute/docs/examples/kriging.ipynb
+++ b/packages/evo-compute/docs/examples/kriging.ipynb
@@ -149,7 +149,7 @@
    "outputs": [],
    "source": [
     "from evo.compute.tasks import SearchNeighborhood, run\n",
-    "from evo.compute.tasks.kriging import KrigingParameters\n",
+    "from evo.compute.tasks.geostatistics.kriging import KrigingParameters\n",
     "\n",
     "# Get ellipsoid from the variogram structure with largest range (default)\n",
     "var_ell = variogram.get_ellipsoid()\n",
@@ -534,7 +534,7 @@
     "from evo.objects.typed import Ellipsoid, EllipsoidRanges, Rotation\n",
     "\n",
     "from evo.compute.tasks import SearchNeighborhood, Target, run\n",
-    "from evo.compute.tasks.kriging import KrigingParameters\n",
+    "from evo.compute.tasks.geostatistics.kriging import KrigingParameters\n",
     "\n",
     "# Create kriging parameters using typed Attribute access\n",
     "# source_pointset_created.locations.attributes[\"elevation\"] gives us an Attribute object\n",

--- a/packages/evo-compute/docs/examples/kriging_multiple.ipynb
+++ b/packages/evo-compute/docs/examples/kriging_multiple.ipynb
@@ -205,7 +205,7 @@
    "outputs": [],
    "source": [
     "from evo.compute.tasks import BlockDiscretisation, SearchNeighborhood\n",
-    "from evo.compute.tasks.kriging import KrigingParameters\n",
+    "from evo.compute.tasks.geostatistics.kriging import KrigingParameters\n",
     "\n",
     "# Define different max_samples values to test\n",
     "max_samples_values = [5, 10, 15, 20]\n",

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -16,7 +16,7 @@ dispatched based on their parameter types using a registry system.
 
 Example:
     >>> from evo.compute.tasks import run, SearchNeighborhood, Target
-    >>> from evo.compute.tasks.kriging import KrigingParameters
+    >>> from evo.compute.tasks.geostatistics.kriging import KrigingParameters
     >>>
     >>> # Run a single task (preview=True required for preview APIs like kriging)
     >>> result = await run(manager, KrigingParameters(...), preview=True)
@@ -37,11 +37,7 @@ from evo.common.interfaces import IFeedback
 from evo.common.utils import create_default_feedback
 
 # Import task modules to trigger registration
-from . import break_ties as _break_ties_module  # noqa: F401
-from . import kriging as _kriging_module  # noqa: F401
-
-# Break Ties-specific result types
-from .break_ties import BreakTiesResult
+from . import geostatistics as _geostatistics_module  # noqa: F401
 
 # Shared components from common module
 from .common import (
@@ -62,8 +58,11 @@ from .common.results import TaskResultList
 # Result types from common (generic base classes)
 from .common.runner import TParams, TResult
 
+# Break Ties-specific result types
+from .geostatistics.break_ties import BreakTiesResult
+
 # Kriging-specific result types
-from .kriging import (
+from .geostatistics.kriging import (
     BlockDiscretisation,
     KrigingResult,
     RegionFilter,
@@ -119,7 +118,7 @@ async def run(
 
     Example (single task):
         >>> from evo.compute.tasks import run, SearchNeighborhood, Target
-        >>> from evo.compute.tasks.kriging import KrigingParameters
+        >>> from evo.compute.tasks.geostatistics.kriging import KrigingParameters
         >>>
         >>> params = KrigingParameters(
         ...     source=pointset.attributes["grade"],

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -68,6 +68,9 @@ from .geostatistics.kriging import (
     RegionFilter,
 )
 
+# Location-Wise result types
+from .geostatistics.location_wise import LocationWiseResult
+
 
 @overload
 async def run(
@@ -165,6 +168,7 @@ __all__ = [
     "Ellipsoid",
     "EllipsoidRanges",
     "KrigingResult",
+    "LocationWiseResult",
     "RegionFilter",
     "Rotation",
     "SearchNeighborhood",

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -1,0 +1,44 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Geostatistics compute tasks.
+
+This package groups all geostatistics-topic compute tasks:
+
+- **kriging** — Kriging interpolation
+- **break_ties** — Spatial tie-breaking
+- **location_wise** — Per-location ensemble statistics
+
+Task modules are imported here to trigger runner registration with the
+central :class:`~evo.compute.tasks.common.runner.TaskRegistry`.
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood
+    >>> from evo.compute.tasks.geostatistics.kriging import KrigingParameters
+    >>>
+    >>> result = await run(manager, KrigingParameters(...), preview=True)
+"""
+
+from . import break_ties as _break_ties_module  # noqa: F401
+from . import kriging as _kriging_module  # noqa: F401
+from .break_ties import BreakTiesResult
+from .kriging import (
+    BlockDiscretisation,
+    KrigingResult,
+    RegionFilter,
+)
+
+__all__ = [
+    "BlockDiscretisation",
+    "BreakTiesResult",
+    "KrigingResult",
+    "RegionFilter",
+]

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -29,16 +29,19 @@ Example:
 
 from . import break_ties as _break_ties_module  # noqa: F401
 from . import kriging as _kriging_module  # noqa: F401
+from . import location_wise as _location_wise_module  # noqa: F401
 from .break_ties import BreakTiesResult
 from .kriging import (
     BlockDiscretisation,
     KrigingResult,
     RegionFilter,
 )
+from .location_wise import LocationWiseResult
 
 __all__ = [
     "BlockDiscretisation",
     "BreakTiesResult",
     "KrigingResult",
+    "LocationWiseResult",
     "RegionFilter",
 ]

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/break_ties.py
@@ -17,7 +17,7 @@ the Break Ties task (geostatistics/break-ties).
 
 Example:
     >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-    >>> from evo.compute.tasks.break_ties import BreakTiesParameters
+    >>> from evo.compute.tasks.geostatistics.break_ties import BreakTiesParameters
     >>>
     >>> params = BreakTiesParameters(
     ...     source=pointset.attributes["grade"],
@@ -40,13 +40,13 @@ from evo.objects import ObjectSchema
 from evo.objects.typed import BaseObject, object_from_reference
 from pydantic import BaseModel
 
-from .common import (
+from ..common import (
     AnySourceAttribute,
     AnyTargetAttribute,
     SearchNeighborhood,
 )
-from .common.results import TaskTarget
-from .common.runner import TaskRunner
+from ..common.results import TaskTarget
+from ..common.runner import TaskRunner
 
 __all__ = [
     "BreakTiesParameters",
@@ -68,7 +68,7 @@ class BreakTiesParameters(BaseModel):
 
     Example:
         >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges, Target
-        >>> from evo.compute.tasks.break_ties import BreakTiesParameters
+        >>> from evo.compute.tasks.geostatistics.break_ties import BreakTiesParameters
         >>>
         >>> params = BreakTiesParameters(
         ...     source=pointset.attributes["grade"],

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py
@@ -17,7 +17,7 @@ the Kriging task (geostatistics/kriging).
 
 Example:
     >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-    >>> from evo.compute.tasks.kriging import KrigingParameters
+    >>> from evo.compute.tasks.geostatistics.kriging import KrigingParameters
     >>>
     >>> params = KrigingParameters(
     ...     source=pointset.attributes["grade"],
@@ -43,15 +43,15 @@ from evo.objects.typed import BaseObject, BlockModelPendingAttribute, PendingAtt
 from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, field_validator, model_serializer
 
 # Import shared components
-from .common import (
+from ..common import (
     AnySourceAttribute,
     AnyTargetAttribute,
     AttributeExpression,
     GeoscienceObjectReference,
     SearchNeighborhood,
 )
-from .common.results import TaskTarget
-from .common.runner import TaskRunner
+from ..common.results import TaskTarget
+from ..common.runner import TaskRunner
 
 __all__ = [
     # Kriging-specific (users import from evo.compute.tasks.kriging)
@@ -220,7 +220,7 @@ class KrigingParameters(BaseModel):
 
     Example:
         >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
-        >>> from evo.compute.tasks.kriging import KrigingParameters, RegionFilter
+        >>> from evo.compute.tasks.geostatistics.kriging import KrigingParameters, RegionFilter
         >>>
         >>> params = KrigingParameters(
         ...     source=pointset.attributes["grade"],  # Source attribute

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/location_wise.py
@@ -1,0 +1,290 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Location-wise compute task client.
+
+This module provides typed dataclass models and convenience functions for running
+the Location-Wise task (geostatistics/location-wise).
+
+Computes per-location statistics across ensemble simulation realizations.
+All operations are optional but at least one must be specified:
+
+- **summary**: min, max, mean, variance (4 attributes)
+- **quantiles**: specified percentiles (N attributes)
+- **probability_above_cutoff**: P(X > cutoff) for each cutoff (N attributes)
+- **mean_above_cutoff**: E[X | X > cutoff] for each cutoff (N attributes)
+
+Example:
+    >>> from evo.compute.tasks import run, Source
+    >>> from evo.compute.tasks.geostatistics.location_wise import (
+    ...     LocationWiseParameters,
+    ...     LocationWiseTarget,
+    ...     ProbabilityAboveCutoff,
+    ... )
+    >>>
+    >>> params = LocationWiseParameters(
+    ...     source=Source(object=grid_url, attribute="cell_attributes[0]"),
+    ...     target=LocationWiseTarget(object=grid_url),
+    ...     summary=True,
+    ...     quantiles=[0.1, 0.5, 0.9],
+    ...     probability_above_cutoff=ProbabilityAboveCutoff(cutoffs=[0.5, 1.0]),
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field
+
+from ..common import (
+    AnySourceAttribute,
+    GeoscienceObjectReference,
+)
+from ..common.results import TaskAttribute
+from ..common.runner import TaskRunner
+
+__all__ = [
+    "LocationWiseParameters",
+    "LocationWiseResult",
+    "LocationWiseResultModel",
+    "LocationWiseRunner",
+    "LocationWiseTarget",
+    "LocationWiseTargetResult",
+    "MeanAboveCutoff",
+    "ProbabilityAboveCutoff",
+]
+
+
+# =============================================================================
+# Location-Wise Target & Option Types
+# =============================================================================
+
+
+class LocationWiseTarget(BaseModel):
+    """Target object for location-wise tasks.
+
+    Only the object reference is needed — the task creates output attributes
+    automatically based on the requested operations.
+    """
+
+    object: GeoscienceObjectReference
+    """Reference URL to the target geoscience object."""
+
+
+class ProbabilityAboveCutoff(BaseModel):
+    """Configuration for probability-above-cutoff operation.
+
+    For each cutoff value, the task computes P(X > cutoff) at every location
+    across all realizations.
+    """
+
+    cutoffs: list[float] = Field(min_length=1)
+    """List of cutoff values. Must contain at least one value."""
+
+
+class MeanAboveCutoff(BaseModel):
+    """Configuration for mean-above-cutoff operation.
+
+    For each cutoff value, the task computes E[X | X > cutoff] at every
+    location across all realizations.
+    """
+
+    cutoffs: list[float] = Field(min_length=1)
+    """List of cutoff values. Must contain at least one value."""
+
+
+# =============================================================================
+# Location-Wise Parameters
+# =============================================================================
+
+
+class LocationWiseParameters(BaseModel):
+    """Parameters for the unified location-wise task.
+
+    At least one operation must be specified (summary, quantiles,
+    probability_above_cutoff, or mean_above_cutoff).
+
+    Example:
+        >>> params = LocationWiseParameters(
+        ...     source=Source(object=grid_url, attribute="cell_attributes[0]"),
+        ...     target=LocationWiseTarget(object=grid_url),
+        ...     summary=True,
+        ...     quantiles=[0.1, 0.5, 0.9],
+        ... )
+    """
+
+    source: AnySourceAttribute
+    """The source object and attribute containing simulation realizations."""
+
+    target: LocationWiseTarget
+    """The target object where computed statistics will be stored."""
+
+    summary: bool | None = None
+    """If True, compute min, max, mean, and variance at each location."""
+
+    quantiles: list[float] | None = None
+    """List of quantile values (0–1) to compute at each location."""
+
+    probability_above_cutoff: ProbabilityAboveCutoff | None = None
+    """Configuration for probability-above-cutoff computation."""
+
+    mean_above_cutoff: MeanAboveCutoff | None = None
+    """Configuration for mean-above-cutoff computation."""
+
+
+# =============================================================================
+# Location-Wise Result Types
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    """Protocol for objects that can convert themselves to a DataFrame."""
+
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class LocationWiseTargetResult(BaseModel):
+    """Target information from a location-wise task result.
+
+    Unlike single-attribute tasks, location-wise produces multiple attributes
+    (one per requested statistic/quantile/cutoff).
+    """
+
+    reference: str
+    """Reference URL to the target object."""
+
+    name: str
+    """Name of the target object."""
+
+    description: str | None = None
+    """Optional description of the target object."""
+
+    schema_id: str
+    """Schema identifier for the target object type."""
+
+    attributes: list[TaskAttribute]
+    """List of attributes created by the task."""
+
+
+class LocationWiseResultModel(BaseModel):
+    """Pydantic model for the raw location-wise task result."""
+
+    message: str
+    """A message describing what happened in the task."""
+
+    target: LocationWiseTargetResult
+    """Target information with the list of created attributes."""
+
+
+class LocationWiseResult:
+    """Result of a location-wise task.
+
+    Provides access to the multiple computed statistics attributes.
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Location-Wise"
+
+    def __init__(self, context: IContext, model: LocationWiseResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        """A message describing what happened in the task."""
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """The reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def attribute_names(self) -> list[str]:
+        """Names of all attributes created by the task."""
+        return [a.name for a in self._target.attributes]
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object.
+
+        Returns:
+            The typed geoscience object (e.g., Regular3DGrid)
+        """
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Get the task results as a DataFrame.
+
+        Args:
+            columns: Optional column names to include. If omitted, returns all.
+
+        Returns:
+            A pandas DataFrame containing the computed statistics.
+        """
+        target_obj = await self.get_target_object()
+
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        else:
+            raise TypeError(
+                f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+                "Use get_target_object() and access the data manually."
+            )
+
+    def __str__(self) -> str:
+        """String representation."""
+        attrs = ", ".join(self.attribute_names)
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:    {self.message}",
+            f"  Target:     {self.target_name}",
+            f"  Attributes: {attrs}",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class LocationWiseRunner(
+    TaskRunner[LocationWiseParameters, LocationWiseResultModel, LocationWiseResult],
+    topic="geostatistics",
+    task="location-wise",
+):
+    """Runner for location-wise compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await LocationWiseRunner(context, params)
+    """
+
+    async def _get_result(self, raw_result: LocationWiseResultModel) -> LocationWiseResult:
+        return LocationWiseResult(self._context, raw_result)

--- a/packages/evo-compute/tests/geostatistics/__init__.py
+++ b/packages/evo-compute/tests/geostatistics/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/packages/evo-compute/tests/geostatistics/test_break_ties_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_break_ties_tasks.py
@@ -24,12 +24,6 @@ from evo.compute.tasks import (
     Target,
     UpdateAttribute,
 )
-from evo.compute.tasks.break_ties import (
-    BreakTiesParameters,
-    BreakTiesResult,
-    BreakTiesResultModel,
-    BreakTiesRunner,
-)
 from evo.compute.tasks.common import (
     Ellipsoid,
     EllipsoidRanges,
@@ -37,6 +31,12 @@ from evo.compute.tasks.common import (
 )
 from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
 from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.break_ties import (
+    BreakTiesParameters,
+    BreakTiesResult,
+    BreakTiesResultModel,
+    BreakTiesRunner,
+)
 
 # ---------------------------------------------------------------------------
 # Test helpers

--- a/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
@@ -39,7 +39,7 @@ from evo.compute.tasks.common import (
     Ellipsoid,
     EllipsoidRanges,
 )
-from evo.compute.tasks.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import KrigingParameters
 
 # ---------------------------------------------------------------------------
 # Test helpers

--- a/packages/evo-compute/tests/geostatistics/test_location_wise_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_location_wise_tasks.py
@@ -1,0 +1,307 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for location-wise task parameter handling."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import Source
+from evo.compute.tasks.common.results import TaskAttribute
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.location_wise import (
+    LocationWiseParameters,
+    LocationWiseResult,
+    LocationWiseResultModel,
+    LocationWiseRunner,
+    LocationWiseTarget,
+    LocationWiseTargetResult,
+    MeanAboveCutoff,
+    ProbabilityAboveCutoff,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+
+
+def _params(**kwargs) -> LocationWiseParameters:
+    defaults = dict(
+        source=Source(object=GRID_URL, attribute="cell_attributes[0]"),
+        target=LocationWiseTarget(object=GRID_URL),
+    )
+    defaults.update(kwargs)
+    return LocationWiseParameters(**defaults)
+
+
+def _dump(params: LocationWiseParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model(attrs=None) -> LocationWiseResultModel:
+    if attrs is None:
+        attrs = [
+            TaskAttribute(reference="ref_p10", name="Quantile: 0.1"),
+            TaskAttribute(reference="ref_p50", name="Quantile: 0.5"),
+            TaskAttribute(reference="ref_p90", name="Quantile: 0.9"),
+        ]
+    return LocationWiseResultModel(
+        message="Location-wise completed.",
+        target=LocationWiseTargetResult(
+            reference=GRID_URL,
+            name="MyGrid",
+            schema_id="/objects/regular-3d-grid/1.3.0/regular-3d-grid.schema.json",
+            attributes=attrs,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(LocationWiseParameters)
+        self.assertIs(runner_cls, LocationWiseRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(LocationWiseRunner.topic, "geostatistics")
+        self.assertEqual(LocationWiseRunner.task, "location-wise")
+
+    def test_runner_types(self):
+        self.assertIs(LocationWiseRunner.params_type, LocationWiseParameters)
+        self.assertIs(LocationWiseRunner.result_model_type, LocationWiseResultModel)
+        self.assertIs(LocationWiseRunner.result_type, LocationWiseResult)
+
+
+# ---------------------------------------------------------------------------
+# Target tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseTarget(unittest.TestCase):
+    def test_target_only_object(self):
+        t = LocationWiseTarget(object=GRID_URL)
+        d = t.model_dump(mode="json", exclude_none=True)
+        self.assertEqual(d["object"], GRID_URL)
+        self.assertNotIn("attribute", d)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseParametersSerialization(unittest.TestCase):
+    def test_summary_only(self):
+        d = _dump(_params(summary=True))
+        self.assertTrue(d["summary"])
+        self.assertNotIn("quantiles", d)
+        self.assertNotIn("probability_above_cutoff", d)
+        self.assertNotIn("mean_above_cutoff", d)
+
+    def test_quantiles_only(self):
+        d = _dump(_params(quantiles=[0.1, 0.5, 0.9]))
+        self.assertEqual(d["quantiles"], [0.1, 0.5, 0.9])
+        self.assertNotIn("summary", d)
+
+    def test_probability_above_cutoff(self):
+        d = _dump(_params(probability_above_cutoff=ProbabilityAboveCutoff(cutoffs=[0.5, 1.0, 2.0])))
+        self.assertEqual(d["probability_above_cutoff"]["cutoffs"], [0.5, 1.0, 2.0])
+
+    def test_mean_above_cutoff(self):
+        d = _dump(_params(mean_above_cutoff=MeanAboveCutoff(cutoffs=[0.5, 1.0])))
+        self.assertEqual(d["mean_above_cutoff"]["cutoffs"], [0.5, 1.0])
+
+    def test_all_operations(self):
+        d = _dump(
+            _params(
+                summary=True,
+                quantiles=[0.1, 0.5, 0.9],
+                probability_above_cutoff=ProbabilityAboveCutoff(cutoffs=[0.5, 1.0]),
+                mean_above_cutoff=MeanAboveCutoff(cutoffs=[0.5]),
+            )
+        )
+        self.assertTrue(d["summary"])
+        self.assertEqual(d["quantiles"], [0.1, 0.5, 0.9])
+        self.assertEqual(d["probability_above_cutoff"]["cutoffs"], [0.5, 1.0])
+        self.assertEqual(d["mean_above_cutoff"]["cutoffs"], [0.5])
+
+    def test_source_format(self):
+        d = _dump(_params(summary=True))
+        self.assertEqual(d["source"]["object"], GRID_URL)
+        self.assertEqual(d["source"]["attribute"], "cell_attributes[0]")
+
+    def test_target_format(self):
+        d = _dump(_params(summary=True))
+        self.assertEqual(d["target"]["object"], GRID_URL)
+
+    def test_none_fields_excluded(self):
+        d = _dump(_params(summary=True))
+        self.assertNotIn("probability_above_cutoff", d)
+        self.assertNotIn("mean_above_cutoff", d)
+        self.assertNotIn("quantiles", d)
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestProbabilityAboveCutoffValidation(unittest.TestCase):
+    def test_empty_cutoffs_rejected(self):
+        with self.assertRaises(Exception):
+            ProbabilityAboveCutoff(cutoffs=[])
+
+    def test_single_cutoff_ok(self):
+        p = ProbabilityAboveCutoff(cutoffs=[1.0])
+        self.assertEqual(p.cutoffs, [1.0])
+
+
+class TestMeanAboveCutoffValidation(unittest.TestCase):
+    def test_empty_cutoffs_rejected(self):
+        with self.assertRaises(Exception):
+            MeanAboveCutoff(cutoffs=[])
+
+    def test_single_cutoff_ok(self):
+        m = MeanAboveCutoff(cutoffs=[1.0])
+        self.assertEqual(m.cutoffs, [1.0])
+
+
+# ---------------------------------------------------------------------------
+# Result model tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseResultModel(unittest.TestCase):
+    def test_result_model_validate(self):
+        data = {
+            "message": "ok",
+            "target": {
+                "reference": GRID_URL,
+                "name": "target",
+                "schema_id": "/objects/regular-3d-grid/1.3.0/regular-3d-grid.schema.json",
+                "attributes": [
+                    {"reference": "ref_1", "name": "attr_1"},
+                    {"reference": "ref_2", "name": "attr_2"},
+                ],
+            },
+        }
+        model = LocationWiseResultModel.model_validate(data)
+        self.assertIsInstance(model, LocationWiseResultModel)
+        self.assertEqual(model.message, "ok")
+        self.assertEqual(len(model.target.attributes), 2)
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseResult(unittest.TestCase):
+    def _make_result(self) -> LocationWiseResult:
+        return LocationWiseResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertIn("completed", self._make_result().message)
+
+    def test_target_name(self):
+        self.assertEqual(self._make_result().target_name, "MyGrid")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make_result().target_reference, GRID_URL)
+
+    def test_attribute_names(self):
+        r = self._make_result()
+        self.assertEqual(r.attribute_names, ["Quantile: 0.1", "Quantile: 0.5", "Quantile: 0.9"])
+
+    def test_summary_attributes(self):
+        summary_attrs = [
+            TaskAttribute(reference="ref_min", name="min"),
+            TaskAttribute(reference="ref_max", name="max"),
+            TaskAttribute(reference="ref_mean", name="mean"),
+            TaskAttribute(reference="ref_var", name="variance"),
+        ]
+        model = _make_result_model(attrs=summary_attrs)
+        r = LocationWiseResult(MagicMock(), model)
+        self.assertEqual(r.attribute_names, ["min", "max", "mean", "variance"])
+
+    def test_str(self):
+        s = str(self._make_result())
+        self.assertIn("Location-Wise", s)
+        self.assertIn("Quantile:", s)
+
+
+# ---------------------------------------------------------------------------
+# Runner behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestLocationWiseRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        connector = MagicMock()
+        context = MagicMock()
+        context.get_connector.return_value = connector
+        context.get_org_id.return_value = "test-org-id"
+        return context
+
+    def _make_job(self):
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+        return job
+
+    async def test_runner_submits_with_correct_topic_and_task(self):
+        context = self._make_context()
+        params = _params(summary=True, quantiles=[0.1, 0.5, 0.9])
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            result = await LocationWiseRunner(context, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "location-wise")
+        self.assertIsInstance(result, LocationWiseResult)
+
+    async def test_runner_preview_defaults_false(self):
+        context = self._make_context()
+        params = _params(summary=True)
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=self._make_job(),
+        ) as mock_submit:
+            await LocationWiseRunner(context, params)
+
+        _, kwargs = mock_submit.call_args
+        self.assertFalse(kwargs.get("preview", True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/evo-compute/tests/test_tasks.py
+++ b/packages/evo-compute/tests/test_tasks.py
@@ -21,7 +21,7 @@ from evo.compute.tasks import run
 from evo.compute.tasks.common.results import TaskAttribute, TaskResultList, TaskTarget
 from evo.compute.tasks.common.runner import TaskRegistry, run_tasks
 from evo.compute.tasks.common.source_target import _convert_object_reference
-from evo.compute.tasks.kriging import (
+from evo.compute.tasks.geostatistics.kriging import (
     KrigingMethod,
     KrigingParameters,
     KrigingResult,


### PR DESCRIPTION
## Summary

This PR reorganizes the `evo-compute` tasks package by grouping geostatistics tasks (kriging, break_ties, location-wise) under a new `tasks/geostatistics/` subpackage, and adds a new **location-wise** compute task SDK client.

## Changes

### 1. Reorganize geostatistics tasks (`refactor`)

Move `kriging.py` and `break_ties.py` from `tasks/` into `tasks/geostatistics/` to group tasks by their compute topic:

```
tasks/
├── __init__.py          # public API (re-exports result types)
├── common.py
├── geostatistics/
│   ├── __init__.py      # registration imports + subpackage exports
│   ├── kriging.py       # moved from tasks/kriging.py
│   ├── break_ties.py    # moved from tasks/break_ties.py
│   └── location_wise.py # NEW
└── ...
```

- Internal relative imports updated (`.common` → `..common`)
- `tasks/__init__.py` updated to import from new locations
- All test, notebook, and documentation import paths updated

### 2. Add location-wise compute task (`feat`)

New task for computing per-location statistics across ensemble simulation realizations:

- **Operations**: summary (min/max/mean/variance), quantiles, probability_above_cutoff, mean_above_cutoff
- **Models**: `LocationWiseParameters`, `LocationWiseResult`, `LocationWiseTarget`, `ProbabilityAboveCutoff`, `MeanAboveCutoff`
- **Runner**: `LocationWiseRunner` registered with `topic="geostatistics"`, `task="location_wise"`
- `LocationWiseResult` exported from `evo.compute.tasks` (consistent with `KrigingResult`, `BreakTiesResult`)
- 25 unit tests covering registration, serialization, validation, result parsing, and runner behavior

### 3. Update CODEOWNERS (`chore`)

Add `@SeequentEvo/geostatistics-maintainers` as code owners for:
- `packages/evo-compute/src/evo/compute/tasks/geostatistics/`
- `packages/evo-compute/tests/test_*_tasks.py`

## Import policy

| What | Import from |
|------|-------------|
| Result types (`KrigingResult`, `BreakTiesResult`, `LocationWiseResult`) | `evo.compute.tasks` |
| Shared models (`Source`, `Target`, `SearchNeighborhood`, etc.) | `evo.compute.tasks` |
| Parameters (`KrigingParameters`, `BreakTiesParameters`, `LocationWiseParameters`) | `evo.compute.tasks.geostatistics.<task>` |

## Testing

All 181 tests pass (break_ties: 24, kriging: 56, location_wise: 25, client: 32, tasks: 44).