### PR TITLE
Fix mkdocs build by only committing on push events

### DIFF
--- a/.github/workflows/mkdocs-build.yaml
+++ b/.github/workflows/mkdocs-build.yaml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && github.event_name == 'push'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Description

Fixed the mkdocs build by only committing on push events. This way the docs are still validated on pull request actions, but not committed.

## Checklist

- [x] I have read the contributing guide and the code of conduct
