### PR TITLE
Use `uv lock --upgrade` as `uv run --no-lock` doesn't exist

### DIFF
--- a/.github/workflows/pypi-compatibility-test.yaml
+++ b/.github/workflows/pypi-compatibility-test.yaml
@@ -1,9 +1,9 @@
 name: PyPI compatibility test
 
 # This workflow simulates the experience of a developer installing our packages fresh from PyPI.
-# Unlike the standard PR/push tests (which use the pinned uv.lock), this runs with --no-lock
-# to resolve the latest available versions of all dependencies from PyPI. This helps catch
-# breaking changes from newly released packages before they hit real users.
+# Unlike the standard PR/push tests (which use the pinned uv.lock), a fresh install resolves
+# the latest available versions of all dependencies, meaning any newly released package could
+# introduce a breaking change that our pinned lockfile wouldn't catch.
 
 permissions:
   contents: read
@@ -14,8 +14,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  resolve-latest-dependencies:
+    name: Resolve latest dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-uv
+
+      - name: Upgrade all dependencies to latest
+        run: uv lock --upgrade
+
+      - name: Upload resolved lockfile
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-deps-uv-lock
+          path: uv.lock
+
   run-tests:
     name: Test
+    needs: resolve-latest-dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +60,11 @@ jobs:
         with:
           PYTHON_VERSION: ${{ matrix.python-version }}
 
+      - name: Download latest resolved lockfile
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-deps-uv-lock
+
       - name: Run tests against latest dependencies
         run: |
-          uv run --package ${{ matrix.package }} --no-lock pytest packages/${{ matrix.package }}/tests/
+          uv run --package ${{ matrix.package }} pytest packages/${{ matrix.package }}/tests/


### PR DESCRIPTION
## Description

Use `uv lock --upgrade` as `uv run --no-lock` doesn't exist.

## Checklist

- [x] I have read the contributing guide and the code of conduct
