### PR TITLE
[Typed objects] Add support for SchemaLocation annotation on ClassVar variables

### DIFF
--- a/packages/evo-objects/src/evo/objects/typed/_data.py
+++ b/packages/evo-objects/src/evo/objects/typed/_data.py
@@ -143,4 +143,5 @@ class DataTableAndAttributes(SchemaModel):
         builder = SchemaBuilder(cls, context)
         await builder.set_sub_model_value("_table", table_df)
         await builder.set_sub_model_value("attributes", attr_df)
-        return builder.document
+
+        return await builder.build_from_data(data, skip_sub_models={"_table", "attributes"})

--- a/packages/evo-objects/src/evo/objects/typed/_data.py
+++ b/packages/evo-objects/src/evo/objects/typed/_data.py
@@ -144,4 +144,5 @@ class DataTableAndAttributes(SchemaModel):
         await builder.set_sub_model_value("_table", table_df)
         await builder.set_sub_model_value("attributes", attr_df)
 
+        # As we specially handle the _table and attributes sub-models above, we skip them in the default data processing of build_from_data.
         return await builder.build_from_data(data, skip_sub_models={"_table", "attributes"})

--- a/packages/evo-objects/src/evo/objects/typed/_model.py
+++ b/packages/evo-objects/src/evo/objects/typed/_model.py
@@ -275,10 +275,11 @@ class SchemaModel:
                 inner_args = get_args(annotation)
                 inner_type = inner_args[0]
                 base_type, schema_location, _ = _get_base_type(inner_type)
+                # Skip class variables without a SchemaLocation, e.g. data_columns: ClassVar[list[str]] = []
                 if schema_location is None:
                     continue
 
-                # Treat such ClassVar fields as constants, which also have a corresponding value in the schema
+                # Treat such remaining ClassVar fields as constants, which also have a corresponding value in the schema
                 type_adapter = TypeAdapter(base_type)
                 prop = SchemaConstantProperty(
                     jmespath_expr=schema_location.jmespath_expr,

--- a/packages/evo-objects/src/evo/objects/typed/_model.py
+++ b/packages/evo-objects/src/evo/objects/typed/_model.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import copy
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Callable, Generic, TypeVar, get_args, get_origin, get_type_hints, overload
+from typing import Annotated, Any, Callable, ClassVar, Generic, TypeVar, get_args, get_origin, get_type_hints, overload
 
 from pydantic import TypeAdapter
 
@@ -86,11 +86,8 @@ class SubModelMetadata:
     """The field name in the data class for this sub-model."""
 
 
-class SchemaProperty(Generic[_T]):
-    """Descriptor for data within a Geoscience Object schema.
-
-    This can be used on either typed objects classes or dataset classes.
-    """
+class BaseSchemaProperty(Generic[_T]):
+    """Base descriptor for reading data from a Geoscience Object schema."""
 
     def __init__(
         self,
@@ -111,7 +108,7 @@ class SchemaProperty(Generic[_T]):
         return self._type_adapter.dump_python(value)
 
     @overload
-    def __get__(self, instance: None, owner: type[SchemaModel]) -> SchemaProperty[_T]: ...
+    def __get__(self, instance: None, owner: type[SchemaModel]) -> BaseSchemaProperty[_T]: ...
 
     @overload
     def __get__(self, instance: SchemaModel, owner: type[SchemaModel]) -> _T: ...
@@ -128,6 +125,13 @@ class SchemaProperty(Generic[_T]):
         # Use TypeAdapter to validate and apply defaults from Field annotations
         return self._type_adapter.validate_python(value)
 
+
+class SchemaProperty(BaseSchemaProperty[_T]):
+    """Descriptor for mutable data within a Geoscience Object schema.
+
+    This can be used on either typed objects classes or dataset classes.
+    """
+
     def __set__(self, instance: SchemaModel, value: Any) -> None:
         _set_property_value(self, instance._document, value)
 
@@ -140,7 +144,19 @@ class SchemaProperty(Generic[_T]):
         _set_property_value(self, document, value)
 
 
-def _set_property_value(schema_property: SchemaProperty, document: dict[str, Any], value: Any) -> None:
+class SchemaConstantProperty(BaseSchemaProperty[_T]):
+    """A SchemaProperty that always writes a fixed value to the schema."""
+
+    def __init__(self, jmespath_expr: str, type_adapter: TypeAdapter[_T], value: _T) -> None:
+        super().__init__(jmespath_expr=jmespath_expr, type_adapter=type_adapter)
+        self._value = value
+
+    @property
+    def value(self) -> _T:
+        return self._value
+
+
+def _set_property_value(schema_property: BaseSchemaProperty, document: dict[str, Any], value: Any) -> None:
     """Set the value of a SchemaProperty by name.
 
     :param property_name: The name of the property to set.
@@ -177,6 +193,26 @@ class SchemaBuilder:
         else:
             self.document.update(sub_document)
 
+    async def build_from_data(self, data: Any, skip_sub_models: set[str] | None = None) -> dict[str, Any]:
+        """Build the schema document by applying all properties and sub-models."""
+        for key, prop in self._properties.items():
+            if isinstance(prop, SchemaConstantProperty):
+                self.set_property(key, prop.value)
+            else:
+                value = getattr(data, key, None)
+                self.set_property(key, value)
+
+        for name, metadata in self._sub_models.items():
+            if skip_sub_models and name in skip_sub_models:
+                continue
+            if metadata.data_field:
+                sub_data = getattr(data, metadata.data_field, None)
+            else:
+                sub_data = data
+            await self.set_sub_model_value(name, sub_data)
+
+        return self.document
+
 
 def _get_base_type(annotation: Any) -> tuple[Any, SchemaLocation | None, DataLocation | None]:
     """Extract the base type and SchemaLocation from an annotation.
@@ -208,14 +244,14 @@ class SchemaModel:
     automatically created for nested SchemaModel/SchemaList fields.
     """
 
-    _schema_properties: dict[str, SchemaProperty[Any]] = {}
+    _schema_properties: dict[str, BaseSchemaProperty[Any]] = {}
     _sub_models: dict[str, SubModelMetadata] = {}
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
         # Initialize with inherited values (copy to avoid mutating parent)
-        schema_properties: dict[str, SchemaProperty[Any]] = {}
+        schema_properties: dict[str, BaseSchemaProperty[Any]] = {}
         sub_models: dict[str, SubModelMetadata] = {}
         for base in cls.__mro__[1:]:
             if issubclass(base, SchemaModel):
@@ -234,6 +270,25 @@ class SchemaModel:
 
         # Process the resolved annotations
         for field_name, annotation in hints.items():
+            # Handle ClassVar fields
+            if get_origin(annotation) is ClassVar:
+                inner_args = get_args(annotation)
+                inner_type = inner_args[0]
+                base_type, schema_location, _ = _get_base_type(inner_type)
+                if schema_location is None:
+                    continue
+
+                # Treat such ClassVar fields as constants, which also have a corresponding value in the schema
+                type_adapter = TypeAdapter(base_type)
+                prop = SchemaConstantProperty(
+                    jmespath_expr=schema_location.jmespath_expr,
+                    type_adapter=type_adapter,
+                    value=getattr(cls, field_name),
+                )
+                setattr(cls, field_name, prop)
+                schema_properties[field_name] = prop
+                continue
+
             base_type, schema_location, data_location = _get_base_type(annotation)
 
             # Skip fields without a SchemaLocation
@@ -348,16 +403,7 @@ class SchemaModel:
         :return: The dictionary representation of the data.
         """
         builder = SchemaBuilder(cls, context)
-        for key in cls._schema_properties.keys():
-            value = getattr(data, key, None)
-            builder.set_property(key, value)
-        for name, metadata in cls._sub_models.items():
-            if metadata.data_field:
-                sub_data = getattr(data, metadata.data_field, None)
-            else:
-                sub_data = data
-            await builder.set_sub_model_value(name, sub_data)
-        return builder.document
+        return await builder.build_from_data(data)
 
     def search(self, expression: str) -> Any:
         """Search the model using a JMESPath expression.

--- a/packages/evo-objects/src/evo/objects/typed/_model.py
+++ b/packages/evo-objects/src/evo/objects/typed/_model.py
@@ -268,14 +268,14 @@ class SchemaModel:
             cls._sub_models = sub_models
             return
 
-        # Process the resolved annotations
+        # Process the resolved annotations, to produce the final set of schema properties and sub-models for this class
         for field_name, annotation in hints.items():
             # Handle ClassVar fields
             if get_origin(annotation) is ClassVar:
                 inner_args = get_args(annotation)
                 inner_type = inner_args[0]
                 base_type, schema_location, _ = _get_base_type(inner_type)
-                # Skip class variables without a SchemaLocation, e.g. data_columns: ClassVar[list[str]] = []
+                # Skip class variables without a SchemaLocation, e.g. data_columns: ClassVar[list[str]] = [],
                 if schema_location is None:
                     continue
 

--- a/packages/evo-objects/src/evo/objects/typed/base.py
+++ b/packages/evo-objects/src/evo/objects/typed/base.py
@@ -227,31 +227,8 @@ class _BaseObject(SchemaModel):
                 "sub_classification and creation_schema_version must be defined by the subclass"
             )
         schema_id = ObjectSchema("objects", cls.sub_classification, cls.creation_schema_version)
-        result: dict[str, Any] = {
-            "schema": str(schema_id),
-        }
-
-        # Handle schema properties
-        for key, prop in cls._schema_properties.items():
-            value = getattr(data, key, None)
-            if value is not None:
-                prop.apply_to(result, value)
-
-        # Handle annotation-based sub-models
-        for name, metadata in cls._sub_models.items():
-            if metadata.data_field:
-                sub_data = getattr(data, metadata.data_field, None)
-            else:
-                sub_data = data
-            if sub_data is not None:
-                from ._utils import assign_jmespath_value
-
-                sub_document = await metadata.model_type._data_to_schema(sub_data, context)
-                if metadata.jmespath_expr:
-                    assign_jmespath_value(result, metadata.jmespath_expr, sub_document)
-                else:
-                    result.update(sub_document)
-
+        result = await super()._data_to_schema(data, context)
+        result["schema"] = str(schema_id)
         return result
 
     @classmethod

--- a/packages/evo-objects/tests/typed/test_model.py
+++ b/packages/evo-objects/tests/typed/test_model.py
@@ -1,0 +1,108 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for base model class and related functionality."""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import Annotated, ClassVar
+from unittest.mock import patch
+
+import pandas as pd
+
+from evo.common import Environment, StaticContext
+from evo.common.test_tools import BASE_URL, ORG, WORKSPACE_ID, TestWithConnector
+from evo.objects.typed._data import DataTable, DataTableAndAttributes
+from evo.objects.typed._model import SchemaBuilder, SchemaLocation, SchemaModel
+from evo.objects.utils.table_formats import FLOAT_ARRAY_3, KnownTableFormat
+
+from .helpers import MockClient
+
+
+class TestSchemaConstants(TestWithConnector):
+    """Tests for ClassVar constant auto-detection in build_from_data."""
+
+    def setUp(self) -> None:
+        TestWithConnector.setUp(self)
+        self.environment = Environment(hub_url=BASE_URL, org_id=ORG.id, workspace_id=WORKSPACE_ID)
+        self.context = StaticContext.from_environment(
+            environment=self.environment,
+            connector=self.connector,
+        )
+
+    async def test_constant_not_overridden_when_data_missing(self):
+        """Test that constant persists when the data object doesn't have the attribute."""
+
+        class ConstantModel(SchemaModel):
+            table_format: ClassVar[str] = "float_array_3"
+            version: ClassVar[Annotated[str, SchemaLocation("format_version")]] = "1.0.0"
+            name: Annotated[str, SchemaLocation("name")]
+
+        @dataclass
+        class FakeData:
+            version: str = "2.0.0"
+            name: str = "test"
+
+        builder = SchemaBuilder(ConstantModel, self.context)
+        result = await builder.build_from_data(FakeData())
+
+        self.assertEqual(result["format_version"], "1.0.0")
+        self.assertEqual(result["name"], "test")
+
+
+class TestTable(DataTable):
+    table_format: ClassVar[KnownTableFormat] = FLOAT_ARRAY_3
+    data_columns: ClassVar[list[str]] = ["x", "y", "z"]
+
+
+class ExtendedLocations(DataTableAndAttributes):
+    _table: Annotated[TestTable, SchemaLocation("coordinates")]
+    point_count: Annotated[int, SchemaLocation("point_count")]
+
+
+class TestDataTableAndAttributesBuildFromData(TestWithConnector):
+    """Tests for DataTableAndAttributes._data_to_schema using build_from_data with skip_sub_models."""
+
+    def setUp(self) -> None:
+        TestWithConnector.setUp(self)
+        self.environment = Environment(hub_url=BASE_URL, org_id=ORG.id, workspace_id=WORKSPACE_ID)
+        self.context = StaticContext.from_environment(
+            environment=self.environment,
+            connector=self.connector,
+        )
+
+    @contextlib.contextmanager
+    def _mock_geoscience_objects(self):
+        mock_client = MockClient(self.environment)
+        with (
+            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+        ):
+            yield mock_client
+
+    async def test_data_to_schema_extra_properties(self):
+        """Test that build_from_data processes additional properties defined on a subclass."""
+
+        # The DataFrame has only coordinate columns (no attributes)
+        df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0], "z": [7.0, 8.0, 9.0]})
+
+        with self._mock_geoscience_objects():
+            result = await ExtendedLocations._data_to_schema(df, self.context)
+
+        # Coordinates and attributes should be handled by the manual set_sub_model_value calls
+        self.assertIn("coordinates", result)
+        self.assertEqual(result["attributes"], [])
+
+        # The extra property is not set because DataFrame doesn't have 'point_count' attribute
+        # (getattr(df, "point_count", None) returns None, which deletes the key)
+        self.assertNotIn("point_count", result)


### PR DESCRIPTION


<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

In preparation for supporting typed objects drillhole collections, this PR makes a couple of changes:
- Support for SchemaLocation annotation on ClassVar variables, which is used to represent constants that appear in the schemas. For example, the [type](https://github.com/SeequentEvo/evo-schemas/blob/8579a26e2df575241abe07cf86d92f1174ab2656/schema/objects/downhole-collection/1.3.1/downhole-collection.schema.json#L15-L19) property within the downhole collections schema.
- Fixed issue where properties and sub models on DataTableAndAttributes sub-classes where being ignored. For downhole collections, the distance tables include a [unit](https://github.com/SeequentEvo/evo-schemas/blob/8579a26e2df575241abe07cf86d92f1174ab2656/schema/components/distance-table/1.2.0/distance-table.schema.json#L31-L34) property which we want include the appropriate class, but this issue caused it to be difficult to expose.   

The proof of concept of the downhole collection object is here: https://github.com/SeequentEvo/evo-data-converters/pull/202

## Checklist

- [x] I have read the contributing guide and the code of conduct
