### PR TITLE
GSTAT-149: add parent_operation_id and root_operation_id params to JobClient.submit for distributed tracing

### DIFF
--- a/mkdocs/site/packages/evo-compute/JobClient.html
+++ b/mkdocs/site/packages/evo-compute/JobClient.html
@@ -513,6 +513,9 @@
     <span class="n">parameters</span><span class="p">:</span> <span class="n">Mapping</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="n">Any</span><span class="p">],</span>
     <span class="n">result_type</span><span class="p">:</span> <span class="nb">type</span><span class="p">[</span><span class="n">T_Result</span><span class="p">]</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">,</span>
     <span class="n">preview</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
+    <span class="o">*</span><span class="p">,</span>
+    <span class="n">parent_operation_id</span><span class="p">:</span> <span class="n">UUID</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+    <span class="n">root_operation_id</span><span class="p">:</span> <span class="n">UUID</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
 <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">JobClient</span><span class="p">[</span><span class="n">T_Result</span><span class="p">]</span>
 </code></pre></div>
 

--- a/packages/evo-compute/src/evo/compute/client.py
+++ b/packages/evo-compute/src/evo/compute/client.py
@@ -174,6 +174,9 @@ class JobClient(Generic[T_Result]):
         parameters: Mapping[str, Any],
         result_type: type[T_Result] = dict,
         preview: bool = False,
+        *,
+        parent_operation_id: UUID | None = None,
+        root_operation_id: UUID | None = None,
     ) -> JobClient[T_Result]:
         """Trigger an asynchronous task within a specific topic with the given parameters.
 
@@ -188,13 +191,20 @@ class JobClient(Generic[T_Result]):
 
         :raises UnknownResponseError: If the Location header is missing or invalid.
         """
+        # parent_operation_id and root_operation_id are intended for internal use only.
+        # They enable distributed tracing across fan-out workflows and require S2S auth on the server side.
+        request_body: dict[str, Any] = {"parameters": dict(parameters)}
+        if parent_operation_id is not None:
+            request_body["parent_operation_id"] = str(parent_operation_id)
+        if root_operation_id is not None:
+            request_body["root_operation_id"] = str(root_operation_id)
 
         async with connector:
             response = await TasksApi(connector).execute_task(
                 org_id=str(org_id),
                 topic=topic,
                 task=task,
-                execute_task_request={"parameters": dict(parameters)},
+                execute_task_request=request_body,
                 additional_headers={"API-Preview": "opt-in"} if preview else {},
             )
 

--- a/packages/evo-compute/tests/test_client.py
+++ b/packages/evo-compute/tests/test_client.py
@@ -417,8 +417,8 @@ class TestJobClientPreview(TestWithConnector):
         )
         self.assertEqual(TEST_JOB_ID, job.id)
 
-    async def test_submit_with_additional_headers(self) -> None:
-        """Test that a job can be submitted with operation IDs for distributed tracing."""
+    async def test_submit_with_operation_ids(self) -> None:
+        """Test that a job can be submitted with parent and root operation IDs for distributed tracing."""
         with self.transport.set_http_response(status_code=303, headers={"Location": self.job_url}):
             job = await JobClient.submit(
                 connector=self.connector,
@@ -445,8 +445,8 @@ class TestJobClientPreview(TestWithConnector):
         )
         self.assertEqual(TEST_JOB_ID, job.id)
 
-    async def test_submit_with_additional_headers_no_preview(self) -> None:
-        """Test that operation IDs work without preview mode."""
+    async def test_submit_with_parent_operation_id_only(self) -> None:
+        """Test that parent_operation_id can be passed without root_operation_id."""
         with self.transport.set_http_response(status_code=303, headers={"Location": self.job_url}):
             job = await JobClient.submit(
                 connector=self.connector,

--- a/packages/evo-compute/tests/test_client.py
+++ b/packages/evo-compute/tests/test_client.py
@@ -417,6 +417,58 @@ class TestJobClientPreview(TestWithConnector):
         )
         self.assertEqual(TEST_JOB_ID, job.id)
 
+    async def test_submit_with_additional_headers(self) -> None:
+        """Test that a job can be submitted with operation IDs for distributed tracing."""
+        with self.transport.set_http_response(status_code=303, headers={"Location": self.job_url}):
+            job = await JobClient.submit(
+                connector=self.connector,
+                org_id=TEST_ORG.id,
+                topic=TEST_TOPIC,
+                task=TEST_TASK,
+                parameters={"foo": "bar"},
+                preview=True,
+                parent_operation_id=UUID("00000000-0000-0000-0000-000000000001"),
+                root_operation_id=UUID("00000000-0000-0000-0000-000000000002"),
+            )
+        self.assert_request_made(
+            RequestMethod.POST,
+            self.task_path,
+            headers={
+                "Content-Type": "application/json",
+                "API-Preview": "opt-in",
+            },
+            body={
+                "parameters": {"foo": "bar"},
+                "parent_operation_id": "00000000-0000-0000-0000-000000000001",
+                "root_operation_id": "00000000-0000-0000-0000-000000000002",
+            },
+        )
+        self.assertEqual(TEST_JOB_ID, job.id)
+
+    async def test_submit_with_additional_headers_no_preview(self) -> None:
+        """Test that operation IDs work without preview mode."""
+        with self.transport.set_http_response(status_code=303, headers={"Location": self.job_url}):
+            job = await JobClient.submit(
+                connector=self.connector,
+                org_id=TEST_ORG.id,
+                topic=TEST_TOPIC,
+                task=TEST_TASK,
+                parameters={"foo": "bar"},
+                parent_operation_id=UUID("00000000-0000-0000-0000-000000000456"),
+            )
+        self.assert_request_made(
+            RequestMethod.POST,
+            self.task_path,
+            headers={
+                "Content-Type": "application/json",
+            },
+            body={
+                "parameters": {"foo": "bar"},
+                "parent_operation_id": "00000000-0000-0000-0000-000000000456",
+            },
+        )
+        self.assertEqual(TEST_JOB_ID, job.id)
+
     async def test_get_status_with_preview(self) -> None:
         """Test that get_status includes the preview header when enabled."""
         response_data = load_test_data("job-response-in-progress.json")


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

### What

Extends `JobClient.submit` in `evo-compute` with two optional parameters for distributed tracing: `parent_operation_id` and `root_operation_id`.

### Why

When building fan-out orchestration workflows — where a single operation spawns multiple parallel compute tasks — there was no way to propagate tracing context through `JobClient.submit`. This made it impossible to correlate child jobs back to their parent operation in distributed tracing systems.

### How

After investigating `compute-task-service`, the correct contract is to pass these IDs as fields in the **request body** (not HTTP headers). The service enforces S2S auth server-side before accepting them, so no security changes are needed on the SDK side.

Changes:
- Added `parent_operation_id: UUID | None` and `root_operation_id: UUID | None` to `JobClient.submit`, serialised into the JSON request body when provided
- Parameters are intentionally **omitted from the public docstring** (internal use only — requires S2S auth)
- Added tests covering both parameters individually and combined with `preview=True`

### Notes

> `parent_operation_id` and `root_operation_id` are intended for internal use by teams building compute tasks. They are excluded from the public API documentation but remain visible in the source signature.
