### PR TITLE
chore: bump evo-compute to v0.0.3

### DIFF
--- a/packages/evo-compute/pyproject.toml
+++ b/packages/evo-compute/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.1.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/uv.lock
+++ b/uv.lock
@@ -946,7 +946,7 @@ test = [
 
 [[package]]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.1.0"
 source = { editable = "packages/evo-compute" }
 dependencies = [
     { name = "evo-blockmodels", extra = ["utils"] },


### PR DESCRIPTION
## Description

Bumps `evo-compute` version from `0.0.2` → `0.0.3` in preparation for a PyPI release.

### What's included in this release

Since `evo-compute@0.0.2`, the following changes have landed on `main`:

- **Break-ties task** — Add break-ties task SDK client (#260)
- **Geostatistics subpackage** — Reorganize tasks into `evo.compute.tasks.geostatistics` subpackage (#266)
- **Location-wise task** — Add location-wise task SDK client (#266)
- **Normal-score task** — Add normal-score task SDK client (#268)

### Release steps after merging

> **Merge PR #268 first**, then merge this PR, then follow the steps below.

1. Go to [Releases → Draft a new release](https://github.com/SeequentEvo/evo-python-sdk/releases/new)
2. Create tag: `evo-compute@v0.0.3` on `main`
3. Select previous tag: `evo-compute@0.0.2`
4. Click **Generate release notes**, curate for evo-compute changes only
5. Click **Publish release** — CI will build and publish to PyPI automatically

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Version bumped in `packages/evo-compute/pyproject.toml`
- [ ] No breaking changes