### PR TITLE
chore: bump evo-compute to v0.0.3

### DIFF
--- a/packages/evo-compute/pyproject.toml
+++ b/packages/evo-compute/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/uv.lock
+++ b/uv.lock
@@ -946,7 +946,7 @@ test = [
 
 [[package]]
 name = "evo-compute"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "packages/evo-compute" }
 dependencies = [
     { name = "evo-blockmodels", extra = ["utils"] },


### PR DESCRIPTION
## Description

Bumps `evo-compute` version from `0.0.2` → `0.0.3` in preparation for a PyPI release.

### What's included in this release

Since `evo-compute@0.0.2`, the following changes have landed on `main`:

- **Break-ties task** — Add break-ties task SDK client (#260)
- **Geostatistics subpackage** — Reorganize tasks into `evo.compute.tasks.geostatistics` subpackage (#266)
- **Location-wise task** — Add location-wise task SDK client (#266)
- **Normal-score task** — Add normal-score task SDK client (#268)

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Version bumped in `packages/evo-compute/pyproject.toml`
- [ ] No breaking changes