### PR TITLE
Expose fill subblocks

### DIFF
--- a/packages/evo-blockmodels/pyproject.toml
+++ b/packages/evo-blockmodels/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-blockmodels"
 description = "Python SDK for using the Seequent Evo Geoscience Block Model API"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-blockmodels/src/evo/blockmodels/client.py
+++ b/packages/evo-blockmodels/src/evo/blockmodels/client.py
@@ -571,8 +571,14 @@ class BlockModelAPIClient(BaseAPIClient):
                 "Cache must be configured to use this method. Please set the 'cache' parameter in the constructor."
             )
         create_result, version = await self._create_block_model(
-            name, grid_definition, description, object_path, coordinate_reference_system, size_unit_id, comment,
-            fill_subblocks
+            name,
+            grid_definition,
+            description,
+            object_path,
+            coordinate_reference_system,
+            size_unit_id,
+            comment,
+            fill_subblocks,
         )
 
         if initial_data is not None:
@@ -793,8 +799,14 @@ class BlockModelAPIClient(BaseAPIClient):
             the block model's own ``fill_subblocks`` setting is used.
         """
         return await self._update_columns(
-            bm_id, data, new_columns, update_columns, delete_columns, units,
-            geometry_change=geometry_change, fill_subblocks=fill_subblocks,
+            bm_id,
+            data,
+            new_columns,
+            update_columns,
+            delete_columns,
+            units,
+            geometry_change=geometry_change,
+            fill_subblocks=fill_subblocks,
         )
 
     async def update_column_metadata(

--- a/packages/evo-blockmodels/src/evo/blockmodels/client.py
+++ b/packages/evo-blockmodels/src/evo/blockmodels/client.py
@@ -223,6 +223,7 @@ class BlockModelAPIClient(BaseAPIClient):
             last_updated_at=model.last_updated_at,
             last_updated_by=ServiceUser.from_model(model.last_updated_by),
             geoscience_object_id=model.geoscience_object_id,
+            fill_subblocks=model.fill_subblocks,
         )
 
     async def _poll_job_url(self, bm_id: UUID, job_id: UUID) -> JobResponse:
@@ -683,6 +684,7 @@ class BlockModelAPIClient(BaseAPIClient):
         delete_columns: set[str] | None = None,
         units: dict[str, str] | None = None,
         geometry_change: bool | None = None,
+        fill_subblocks: bool | None = None,
     ) -> Version:
         if self._cache is None:
             raise CacheNotConfiguredException(
@@ -724,6 +726,7 @@ class BlockModelAPIClient(BaseAPIClient):
                 columns=columns,
                 update_type=models.UpdateType.replace,
                 geometry_change=geometry_change,
+                **({} if fill_subblocks is None else {"fill_subblocks": fill_subblocks}),
             ),
         )
         return await self._upload_data(bm_id, update_response.job_uuid, str(update_response.upload_url), data)
@@ -765,6 +768,7 @@ class BlockModelAPIClient(BaseAPIClient):
         delete_columns: set[str] | None = None,
         units: dict[str, str] | None = None,
         geometry_change: bool = False,
+        fill_subblocks: bool | None = None,
     ) -> Version:
         """Add, update, or delete sub-blocked block model columns.
 
@@ -784,9 +788,13 @@ class BlockModelAPIClient(BaseAPIClient):
         :param delete_columns: A set of column names to delete from the block model.
         :param units: A dictionary mapping column names within `data` to units.
         :param geometry_change: Whether the geometry of the sub-blocked model changes.
+        :param fill_subblocks: If ``True``, any missing sub-blocks will be filled with data from the parent block.
+            Only applicable for fully sub-blocked models when ``geometry_change`` is ``True``. If ``None`` (the default),
+            the block model's own ``fill_subblocks`` setting is used.
         """
         return await self._update_columns(
-            bm_id, data, new_columns, update_columns, delete_columns, units, geometry_change=geometry_change
+            bm_id, data, new_columns, update_columns, delete_columns, units,
+            geometry_change=geometry_change, fill_subblocks=fill_subblocks,
         )
 
     async def update_column_metadata(

--- a/packages/evo-blockmodels/src/evo/blockmodels/client.py
+++ b/packages/evo-blockmodels/src/evo/blockmodels/client.py
@@ -249,6 +249,7 @@ class BlockModelAPIClient(BaseAPIClient):
         coordinate_reference_system: str | None = None,
         size_unit_id: str | None = None,
         comment: str | None = None,
+        fill_subblocks: bool = False,
     ) -> tuple[models.BlockModelAndJobURL, Version]:
         match grid_definition:
             case RegularGridDefinition(n_blocks=n_blocks, block_size=block_size):
@@ -295,6 +296,7 @@ class BlockModelAPIClient(BaseAPIClient):
                 object_path=object_path,
                 coordinate_reference_system=coordinate_reference_system,
                 size_unit_id=size_unit_id,
+                fill_subblocks=fill_subblocks,
                 model_origin=Location(
                     x=grid_definition.model_origin[0],
                     y=grid_definition.model_origin[1],
@@ -532,6 +534,7 @@ class BlockModelAPIClient(BaseAPIClient):
         initial_data: Table | None = None,
         units: dict[str, str] | None = None,
         comment: str | None = None,
+        fill_subblocks: bool = False,
     ) -> tuple[BlockModel, Version]:
         r"""Create a block model.
 
@@ -555,6 +558,9 @@ class BlockModelAPIClient(BaseAPIClient):
         :param initial_data: The initial data to populate the block model with.
         :param units: A dictionary mapping column names within `initial_data` to units.
         :param comment: An optional comment describing the initial data.
+        :param fill_subblocks: Sets the default fill_subblocks behaviour for this block model. If ``True``, updates to a
+            fully sub-blocked model with ``update_type``=``merge`` and ``geometry_change``=``True`` will fill any missing
+            sub-blocks with data from the parent block. Defaults to ``False``.
         :return: A tuple containing the created block model and the version of the block model.
         """
         if units is not None and initial_data is None:
@@ -564,7 +570,8 @@ class BlockModelAPIClient(BaseAPIClient):
                 "Cache must be configured to use this method. Please set the 'cache' parameter in the constructor."
             )
         create_result, version = await self._create_block_model(
-            name, grid_definition, description, object_path, coordinate_reference_system, size_unit_id, comment
+            name, grid_definition, description, object_path, coordinate_reference_system, size_unit_id, comment,
+            fill_subblocks
         )
 
         if initial_data is not None:

--- a/packages/evo-blockmodels/src/evo/blockmodels/data.py
+++ b/packages/evo-blockmodels/src/evo/blockmodels/data.py
@@ -161,6 +161,14 @@ class BlockModel(ResourceMetadata):
     User who last updated the block model, including metadata updates
     """
 
+    fill_subblocks: bool = False
+    """
+    Sets the default fill_subblocks behaviour for this block model.
+
+    If ``True``, updates to a fully sub-blocked model with ``update_type``=``merge`` and ``geometry_change``=``True``
+    will fill any missing sub-blocks with data from the parent block.
+    """
+
     @property
     def url(self) -> str:
         """The url of the block model version."""

--- a/packages/evo-blockmodels/tests/test_create.py
+++ b/packages/evo-blockmodels/tests/test_create.py
@@ -56,7 +56,7 @@ SUBBLOCKED_GRID_DEFINITION = FullySubBlockedGridDefinition(
 )
 
 
-def _mock_create_result(environment, size_options=None) -> models.BlockModelAndJobURL:
+def _mock_create_result(environment, size_options=None, fill_subblocks: bool = False) -> models.BlockModelAndJobURL:
     if size_options is None:
         size_options = models.SizeOptionsRegular(
             model_type="regular",
@@ -82,6 +82,7 @@ def _mock_create_result(environment, size_options=None) -> models.BlockModelAndJ
         last_updated_at=DATE,
         last_updated_by=MODEL_USER,
         job_url=f"{BASE_URL}/jobs/{uuid.uuid4()}",
+        fill_subblocks=fill_subblocks,
     )
 
 
@@ -316,6 +317,7 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
         self.assertEqual(bm.created_by, USER)
         self.assertEqual(bm.last_updated_at, DATE)
         self.assertEqual(bm.last_updated_by, USER)
+        self.assertEqual(bm.fill_subblocks, False)
 
         self.assertEqual(version.bm_uuid, BM_UUID)
         self.assertEqual(version.version_id, 1)
@@ -361,7 +363,7 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
     async def test_create_block_model_with_fill_subblocks(self) -> None:
         self.transport.set_request_handler(
             CreateRequestHandler(
-                create_result=_mock_create_result(self.environment),
+                create_result=_mock_create_result(self.environment, fill_subblocks=True),
                 job_response=JobResponse(
                     job_status=JobStatus.COMPLETE,
                     payload=FIRST_VERSION,
@@ -378,6 +380,7 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
             fill_subblocks=True,
         )
         self.assertEqual(bm.id, BM_UUID)
+        self.assertEqual(bm.fill_subblocks, True)
         self.assertEqual(version.version_id, 1)
 
         self._assert_create_request(SUBBLOCKED_GRID_DEFINITION, fill_subblocks=True)

--- a/packages/evo-blockmodels/tests/test_create.py
+++ b/packages/evo-blockmodels/tests/test_create.py
@@ -182,7 +182,9 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
     def base_path(self) -> str:
         return f"blockmodel/orgs/{self.environment.org_id}/workspaces/{self.environment.workspace_id}"
 
-    def _assert_create_request(self, definition: BaseGridDefinition, comment: str | None = None) -> None:
+    def _assert_create_request(
+        self, definition: BaseGridDefinition, comment: str | None = None, fill_subblocks: bool = False
+    ) -> None:
         match definition:
             case RegularGridDefinition():
                 size_options = models.SizeOptionsRegular(
@@ -271,6 +273,7 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
                 size_unit_id="m",
                 object_path="test/path",
                 comment=comment,
+                fill_subblocks=fill_subblocks,
             ).model_dump(mode="json", exclude_unset=True),
             headers={
                 "Authorization": "Bearer <not-a-real-token>",
@@ -354,6 +357,30 @@ class TestCreateBlockModel(TestWithConnector, TestWithStorage):
         self.assertEqual(version.comment, "Initial creation")
 
         self._assert_create_request(GRID_DEFINITION, comment="Initial creation")
+
+    async def test_create_block_model_with_fill_subblocks(self) -> None:
+        self.transport.set_request_handler(
+            CreateRequestHandler(
+                create_result=_mock_create_result(self.environment),
+                job_response=JobResponse(
+                    job_status=JobStatus.COMPLETE,
+                    payload=FIRST_VERSION,
+                ),
+            )
+        )
+        bm, version = await self.bms_client.create_block_model(
+            name="Test BM",
+            description="Test Block Model",
+            grid_definition=SUBBLOCKED_GRID_DEFINITION,
+            object_path="test/path",
+            coordinate_reference_system="EPSG:4326",
+            size_unit_id="m",
+            fill_subblocks=True,
+        )
+        self.assertEqual(bm.id, BM_UUID)
+        self.assertEqual(version.version_id, 1)
+
+        self._assert_create_request(SUBBLOCKED_GRID_DEFINITION, fill_subblocks=True)
 
     async def test_create_block_model_with_data(self) -> None:
         second_version = _mock_version(

--- a/packages/evo-blockmodels/tests/test_update.py
+++ b/packages/evo-blockmodels/tests/test_update.py
@@ -480,6 +480,63 @@ class TestUpdateBlockModel(TestWithConnector, TestWithStorage):
         self.assertEqual(version.created_by, USER)
         self.assertEqual(version.columns, UPDATED_VERSION.mapping.columns)
 
+    async def test_update_subblocked_columns_with_fill_subblocks(self) -> None:
+        """Test that fill_subblocks is passed through to UpdateDataLiteInput."""
+        self.transport.set_request_handler(
+            UpdateRequestHandler(
+                update_result=UPDATE_RESULT,
+                job_response=JobResponse(
+                    job_status=JobStatus.COMPLETE,
+                    payload=UPDATED_VERSION,
+                ),
+            )
+        )
+        with (
+            mock.patch("evo.common.io.upload.StorageDestination") as mock_destination,
+        ):
+            mock_destination.upload_file = mock.AsyncMock()
+            version = await self.bms_client.update_subblocked_columns(
+                BM_UUID,
+                SUBBLOCKED_DATA,
+                new_columns=["col2"],
+                update_columns={"col1"},
+                delete_columns={"col3"},
+                units={"col2": "g/t"},
+                geometry_change=True,
+                fill_subblocks=True,
+            )
+            mock_destination.upload_file.assert_called_once()
+
+            expected_update_body = models.UpdateDataLiteInput(
+                columns=models.UpdateColumnsLiteInput(
+                    new=[
+                        models.ColumnLite(
+                            title="col2",
+                            data_type=models.DataType.Float64,
+                            unit_id="g/t",
+                        ),
+                    ],
+                    update=["col1"],
+                    rename=[],
+                    delete=["col3"],
+                ),
+                update_type=models.UpdateType.replace,
+                geometry_change=True,
+                fill_subblocks=True,
+            )
+            self.assert_any_request_made(
+                method=RequestMethod.PATCH,
+                path=f"{self.base_path}/block-models/{BM_UUID}/blocks",
+                body=expected_update_body.model_dump(mode="json", exclude_unset=True),
+                headers={
+                    "Authorization": "Bearer <not-a-real-token>",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+            )
+        self.assertEqual(version.bm_uuid, BM_UUID)
+        self.assertEqual(version.version_id, 2)
+
     async def test_update_column_metadata(self) -> None:
         self.transport.set_request_handler(
             UpdateRequestHandler(

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "evo-blockmodels"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/evo-blockmodels" }
 dependencies = [
     { name = "evo-sdk-common" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct

Exposed the property when getting block models as well as allowing the property to be set.
Arguably it is not very relevant for some types of block models... so client exposes it, but typed objects (like regular block models - do not). No typed support for sub-blocked models yet though.