### PR TITLE
Add declustering compute task SDK client

### DIFF
--- a/mkdocs/site/packages/evo-compute/typed-objects/break-ties/BreakTiesRunner.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/break-ties/BreakTiesRunner.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../kriging/BlockDiscretisation.html" class="nav-link">
+                                <a rel="next" href="../declustering/DeclusteringParameters.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../break-ties/BreakTiesRunner.html" class="nav-link">
+                                <a rel="prev" href="../declustering/knn.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -61,6 +61,9 @@ from .common.runner import TParams, TResult
 # Break Ties-specific result types
 from .geostatistics.break_ties import BreakTiesResult
 
+# Declustering result types
+from .geostatistics.declustering import DeclusteringResult
+
 # Kriging-specific result types
 from .geostatistics.kriging import (
     BlockDiscretisation,
@@ -165,6 +168,7 @@ __all__ = [
     "BlockDiscretisation",
     "BreakTiesResult",
     "CreateAttribute",
+    "DeclusteringResult",
     "Ellipsoid",
     "EllipsoidRanges",
     "KrigingResult",

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -15,7 +15,12 @@ This package groups all geostatistics-topic compute tasks:
 
 - **kriging** — Kriging interpolation
 - **break_ties** — Spatial tie-breaking
+- **declustering** — Grid-based declustering weights
 - **location_wise** — Per-location ensemble statistics
+- **loss_calculation** — Classification by expected economic loss
+- **normal_score** — Normal score transformation
+- **profit_calculation** — Classification by expected economic profit
+- **simulation_report** — Simulation result reporting
 
 Task modules are imported here to trigger runner registration with the
 central :class:`~evo.compute.tasks.common.runner.TaskRegistry`.
@@ -28,6 +33,7 @@ Example:
 """
 
 from . import break_ties as _break_ties_module  # noqa: F401
+from . import declustering as _declustering_module  # noqa: F401
 from . import kriging as _kriging_module  # noqa: F401
 from . import location_wise as _location_wise_module  # noqa: F401
 from . import loss_calculation as _loss_calculation_module  # noqa: F401
@@ -35,6 +41,7 @@ from . import normal_score as _normal_score_module  # noqa: F401
 from . import profit_calculation as _profit_calculation_module  # noqa: F401
 from . import simulation_report as _simulation_report_module  # noqa: F401
 from .break_ties import BreakTiesResult
+from .declustering import DeclusteringResult
 from .kriging import (
     BlockDiscretisation,
     KrigingResult,
@@ -45,6 +52,7 @@ from .location_wise import LocationWiseResult
 __all__ = [
     "BlockDiscretisation",
     "BreakTiesResult",
+    "DeclusteringResult",
     "KrigingResult",
     "LocationWiseResult",
     "RegionFilter",

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/declustering.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/declustering.py
@@ -1,0 +1,365 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Declustering compute task client.
+
+This module provides typed models for running the declustering task
+(geostatistics/declustering).  The task computes grid-based declustering
+weights by measuring each sample's influence on evaluation locations.
+
+Two estimation modes are supported via factory functions:
+
+- :func:`idw` — inverse-distance weighting (default ``power=2.0``)
+- :func:`knn` — nearest-neighbour (equal weights, typically ``max_samples=1``)
+
+Example — IDW declustering:
+    >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges, Target
+    >>> from evo.compute.tasks.geostatistics.declustering import idw
+    >>>
+    >>> params = idw(
+    ...     source=pointset,
+    ...     grid=regular_grid,
+    ...     target=Target.new_attribute(pointset, "declustering_weights"),
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=20,
+    ...     ),
+    ... )
+    >>> result = await run(context, params)
+
+Example — KNN declustering:
+    >>> from evo.compute.tasks.geostatistics.declustering import knn
+    >>>
+    >>> params = knn(
+    ...     source=pointset,
+    ...     grid=regular_grid,
+    ...     target=Target.new_attribute(pointset, "declustering_weights"),
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=1,
+    ...     ),
+    ... )
+    >>> result = await run(context, params)
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, BeforeValidator, Field, SerializerFunctionWrapHandler, model_serializer
+
+from ..common import (
+    AnyTargetAttribute,
+    GeoscienceObjectReference,
+    SearchNeighborhood,
+)
+from ..common.results import TaskTarget
+from ..common.runner import TaskRunner
+from ..common.source_target import _convert_object_reference
+
+__all__ = [
+    "DeclusteringParameters",
+    "DeclusteringResult",
+    "DeclusteringResultModel",
+    "DeclusteringRunner",
+    "DeclusteringSource",
+    "idw",
+    "knn",
+]
+
+
+# =============================================================================
+# Shared input models
+# =============================================================================
+
+
+class DeclusteringSource(BaseModel):
+    """Source sample locations for declustering weight computation."""
+
+    object: GeoscienceObjectReference
+    """Reference to the spatial object containing sample locations."""
+
+
+class DeclusteringGrid(BaseModel):
+    """Evaluation grid used for computing sample influence."""
+
+    object: GeoscienceObjectReference
+    """Reference to a regular grid or set of evaluation locations."""
+
+
+def _wrap_source(v: Any) -> DeclusteringSource:
+    """Accept a raw object reference and wrap it in DeclusteringSource."""
+    if isinstance(v, DeclusteringSource):
+        return v
+    return DeclusteringSource(object=_convert_object_reference(v))
+
+
+def _wrap_grid(v: Any) -> DeclusteringGrid:
+    """Accept a raw object reference and wrap it in DeclusteringGrid."""
+    if isinstance(v, DeclusteringGrid):
+        return v
+    return DeclusteringGrid(object=_convert_object_reference(v))
+
+
+AnyDeclusteringSource = Annotated[DeclusteringSource, BeforeValidator(_wrap_source)]
+AnyDeclusteringGrid = Annotated[DeclusteringGrid, BeforeValidator(_wrap_grid)]
+
+
+# =============================================================================
+# Declustering Parameters
+# =============================================================================
+
+
+class DeclusteringParameters(BaseModel):
+    """Parameters for the declustering task.
+
+    Computes grid-based declustering weights by measuring each sample's
+    influence on evaluation locations.
+
+    The ``power`` parameter controls the estimation mode:
+
+    - ``power=2.0`` (default) — inverse-distance weighting (IDW)
+    - ``power=None`` — arithmetic-mean KNN (equal neighbour weights)
+
+    Example:
+        >>> params = DeclusteringParameters(
+        ...     source=pointset,
+        ...     grid=regular_grid,
+        ...     target=Target.new_attribute(pointset, "weights"),
+        ...     neighborhood=SearchNeighborhood(
+        ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+        ...         max_samples=20,
+        ...     ),
+        ... )
+    """
+
+    source: AnyDeclusteringSource
+    """Source sample locations (accepts a geoscience object directly)."""
+
+    grid: AnyDeclusteringGrid
+    """Evaluation grid for measuring sample influence (accepts a geoscience object directly)."""
+
+    target: AnyTargetAttribute
+    """Target object and attribute to write declustering weights to."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighborhood parameters."""
+
+    power: float | None = Field(default=2.0, gt=0.0)
+    """Inverse-distance weighting power.
+
+    Controls how strongly distance affects influence: higher values give
+    nearer samples more weight.  Set to ``None`` to use KNN mode
+    (arithmetic-mean, equal neighbour votes).
+
+    Default is ``2.0`` (standard IDW).  Must be positive when provided.
+    """
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        result = handler(self)
+        # Explicitly include power even when None so exclude_none=True in
+        # TaskRunner.__call__ doesn't drop it — the server interprets a
+        # missing power as IDW with the default, while null means KNN.
+        if self.power is None:
+            result["power"] = None
+        return result
+
+
+# =============================================================================
+# Factory functions
+# =============================================================================
+
+
+def idw(
+    source: Any,
+    grid: Any,
+    target: AnyTargetAttribute,
+    neighborhood: SearchNeighborhood,
+    *,
+    power: float = 2.0,
+) -> DeclusteringParameters:
+    """Create IDW (inverse-distance weighting) declustering parameters.
+
+    Higher ``power`` values give nearer samples more weight.
+
+    Args:
+        source: Source sample locations (geoscience object URL or DeclusteringSource).
+        grid: Evaluation grid (geoscience object URL or DeclusteringGrid).
+        target: Target object and attribute to write declustering weights to.
+        neighborhood: Search neighborhood parameters.
+        power: IDW power exponent.  Default ``2.0``.  Must be positive.
+
+    Returns:
+        Configured DeclusteringParameters ready for ``run()``.
+    """
+    return DeclusteringParameters(
+        source=source,
+        grid=grid,
+        target=target,
+        neighborhood=neighborhood,
+        power=power,
+    )
+
+
+def knn(
+    source: Any,
+    grid: Any,
+    target: AnyTargetAttribute,
+    neighborhood: SearchNeighborhood,
+) -> DeclusteringParameters:
+    """Create KNN (nearest-neighbour) declustering parameters.
+
+    Uses equal neighbour weights (arithmetic mean).  For true
+    nearest-neighbour behaviour, set ``max_samples=1`` on the
+    :class:`~evo.compute.tasks.common.SearchNeighborhood`.
+
+    Args:
+        source: Source sample locations (geoscience object URL or DeclusteringSource).
+        grid: Evaluation grid (geoscience object URL or DeclusteringGrid).
+        target: Target object and attribute to write declustering weights to.
+        neighborhood: Search neighborhood parameters.
+
+    Returns:
+        Configured DeclusteringParameters ready for ``run()``.
+    """
+    return DeclusteringParameters(
+        source=source,
+        grid=grid,
+        target=target,
+        neighborhood=neighborhood,
+        power=None,
+    )
+
+
+# =============================================================================
+# Declustering Result Types
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    """Protocol for objects that can convert themselves to a DataFrame."""
+
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class DeclusteringResultModel(BaseModel):
+    """Pydantic model for the raw declustering task result."""
+
+    message: str
+    """A message describing what happened in the task."""
+
+    target: TaskTarget
+    """Target information from the task result."""
+
+
+class DeclusteringResult:
+    """Rich wrapper around the declustering task result.
+
+    Provides convenience properties and methods for accessing the
+    computed declustering weights.
+    """
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "Declustering"
+
+    def __init__(self, context: IContext, model: DeclusteringResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        """A message describing what happened in the task."""
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """Reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        """The name of the attribute containing declustering weights."""
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object.
+
+        Returns:
+            The typed geoscience object containing the declustering weights.
+        """
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Get the declustering weights as a DataFrame.
+
+        Args:
+            columns: Optional column names to include. If omitted, returns all columns.
+
+        Returns:
+            A pandas DataFrame containing the declustering weight values.
+        """
+        target_obj = await self.get_target_object()
+
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        else:
+            raise TypeError(
+                f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+                "Use get_target_object() and access the data manually."
+            )
+
+    def __str__(self) -> str:
+        """String representation."""
+        lines = [
+            f"✓ {self.TASK_DISPLAY_NAME} Result",
+            f"  Message:   {self.message}",
+            f"  Target:    {self.target_name}",
+            f"  Attribute: {self.attribute_name}",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class DeclusteringRunner(
+    TaskRunner[DeclusteringParameters, DeclusteringResultModel, DeclusteringResult],
+    topic="geostatistics",
+    task="declustering",
+):
+    """Runner for declustering compute tasks.
+
+    Automatically registered — used by ``run()`` for dispatch, or directly::
+
+        result = await DeclusteringRunner(context, params)
+    """
+
+    async def _get_result(self, raw_result: DeclusteringResultModel) -> DeclusteringResult:
+        return DeclusteringResult(self._context, raw_result)

--- a/packages/evo-compute/tests/geostatistics/test_declustering_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_declustering_tasks.py
@@ -1,0 +1,359 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for declustering task parameter handling."""
+
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pydantic import ValidationError
+
+from evo.compute.tasks import (
+    CreateAttribute,
+    SearchNeighborhood,
+    Target,
+    UpdateAttribute,
+)
+from evo.compute.tasks.common import (
+    Ellipsoid,
+    EllipsoidRanges,
+    Rotation,
+)
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.declustering import (
+    DeclusteringParameters,
+    DeclusteringResult,
+    DeclusteringResultModel,
+    DeclusteringRunner,
+    DeclusteringSource,
+    idw,
+    knn,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+TARGET_URL = _obj_url("00000000-0000-0000-0000-000000000030")
+
+
+def _search(
+    major: float = 200.0, semi_major: float = 150.0, minor: float = 100.0, max_samples: int = 20
+) -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=major, semi_major=semi_major, minor=minor)),
+        max_samples=max_samples,
+    )
+
+
+def _make_result_model(target_name: str = "MyPointset", attr_name: str = "weights") -> DeclusteringResultModel:
+    return DeclusteringResultModel(
+        message="Declustering completed successfully.",
+        target=TaskTarget(
+            reference=TARGET_URL,
+            name=target_name,
+            description=None,
+            schema_id="/objects/pointset/1.3.0/pointset.schema.json",
+            attribute=TaskAttribute(reference="locations.attributes[?name=='weights']", name=attr_name),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeclusteringRegistration(TestCase):
+    def test_declustering_parameters_registered(self):
+        registry = TaskRegistry()
+        runner_cls = registry.get_runner(DeclusteringParameters)
+        self.assertIsNotNone(runner_cls)
+        self.assertIs(runner_cls, DeclusteringRunner)
+
+    def test_runner_topic_and_task(self):
+        self.assertEqual(DeclusteringRunner.topic, "geostatistics")
+        self.assertEqual(DeclusteringRunner.task, "declustering")
+
+    def test_runner_types(self):
+        self.assertIs(DeclusteringRunner.params_type, DeclusteringParameters)
+        self.assertIs(DeclusteringRunner.result_model_type, DeclusteringResultModel)
+        self.assertIs(DeclusteringRunner.result_type, DeclusteringResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeclusteringParametersSerialization(TestCase):
+    def _params(self, **kwargs) -> DeclusteringParameters:
+        defaults = dict(
+            source=POINTSET_URL,
+            grid=GRID_URL,
+            target=Target(object=TARGET_URL, attribute=CreateAttribute(name="weights")),
+            neighborhood=_search(),
+        )
+        defaults.update(kwargs)
+        return DeclusteringParameters(**defaults)
+
+    def _dump(self, params: DeclusteringParameters) -> dict:
+        return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    def test_source_serializes_correctly(self):
+        d = self._dump(self._params())
+        self.assertEqual(d["source"]["object"], POINTSET_URL)
+
+    def test_source_accepts_raw_url(self):
+        params = self._params(source=POINTSET_URL)
+        self.assertIsInstance(params.source, DeclusteringSource)
+        self.assertEqual(str(params.source.object), POINTSET_URL)
+
+    def test_grid_serializes_correctly(self):
+        d = self._dump(self._params())
+        self.assertEqual(d["grid"]["object"], GRID_URL)
+
+    def test_target_create_serializes_correctly(self):
+        d = self._dump(self._params())
+        self.assertEqual(d["target"]["object"], TARGET_URL)
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+        self.assertEqual(d["target"]["attribute"]["name"], "weights")
+
+    def test_target_update_serializes_correctly(self):
+        params = self._params(
+            target=Target(
+                object=TARGET_URL, attribute=UpdateAttribute(reference="locations.attributes[?name=='weights']")
+            )
+        )
+        d = self._dump(params)
+        self.assertEqual(d["target"]["attribute"]["operation"], "update")
+
+    def test_neighborhood_serializes_correctly(self):
+        d = self._dump(self._params())
+        nbh = d["neighborhood"]
+        self.assertIn("ellipsoid", nbh)
+        self.assertEqual(nbh["max_samples"], 20)
+
+    def test_default_power_is_idw(self):
+        params = self._params()
+        self.assertEqual(params.power, 2.0)
+
+    def test_default_power_in_serialized_output(self):
+        d = self._dump(self._params())
+        self.assertEqual(d["power"], 2.0)
+
+    def test_custom_power(self):
+        d = self._dump(self._params(power=3.0))
+        self.assertEqual(d["power"], 3.0)
+
+    def test_knn_mode_power_none(self):
+        params = self._params(power=None)
+        self.assertIsNone(params.power)
+
+    def test_knn_power_none_preserved_with_exclude_none(self):
+        """When power=None, serialization must explicitly include power: null."""
+        d = self._dump(self._params(power=None))
+        self.assertIn("power", d)
+        self.assertIsNone(d["power"])
+
+    def test_negative_power_rejected(self):
+        with self.assertRaises(ValidationError):
+            self._params(power=-1.0)
+
+    def test_zero_power_rejected(self):
+        with self.assertRaises(ValidationError):
+            self._params(power=0.0)
+
+    def test_neighborhood_with_rotation(self):
+        params = self._params(
+            neighborhood=SearchNeighborhood(
+                ellipsoid=Ellipsoid(
+                    ranges=EllipsoidRanges(major=300, semi_major=200, minor=100),
+                    rotation=Rotation(dip_azimuth=45.0, dip=30.0, pitch=0.0),
+                ),
+                max_samples=16,
+            )
+        )
+        d = self._dump(params)
+        rotation = d["neighborhood"]["ellipsoid"]["rotation"]
+        self.assertEqual(rotation["dip_azimuth"], 45.0)
+        self.assertEqual(rotation["dip"], 30.0)
+
+
+# ---------------------------------------------------------------------------
+# Factory function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeclusteringFactoryFunctions(TestCase):
+    def _target(self):
+        return Target(object=TARGET_URL, attribute=CreateAttribute(name="weights"))
+
+    def test_idw_returns_declustering_parameters(self):
+        params = idw(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertIsInstance(params, DeclusteringParameters)
+
+    def test_idw_default_power(self):
+        params = idw(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertEqual(params.power, 2.0)
+
+    def test_idw_custom_power(self):
+        params = idw(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search(), power=3.5)
+        self.assertEqual(params.power, 3.5)
+
+    def test_idw_serializes_power(self):
+        params = idw(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        d = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+        self.assertEqual(d["power"], 2.0)
+
+    def test_knn_returns_declustering_parameters(self):
+        params = knn(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertIsInstance(params, DeclusteringParameters)
+
+    def test_knn_power_is_none(self):
+        params = knn(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertIsNone(params.power)
+
+    def test_knn_preserves_null_power_in_serialization(self):
+        params = knn(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        d = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+        self.assertIn("power", d)
+        self.assertIsNone(d["power"])
+
+    def test_knn_with_single_neighbor(self):
+        params = knn(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search(max_samples=1))
+        self.assertIsNone(params.power)
+        d = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+        self.assertEqual(d["neighborhood"]["max_samples"], 1)
+
+    def test_idw_wraps_source_url(self):
+        params = idw(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertIsInstance(params.source, DeclusteringSource)
+
+    def test_knn_wraps_source_url(self):
+        params = knn(source=POINTSET_URL, grid=GRID_URL, target=self._target(), neighborhood=_search())
+        self.assertIsInstance(params.source, DeclusteringSource)
+
+
+# ---------------------------------------------------------------------------
+# Result wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeclusteringResult(TestCase):
+    def _result(self, **kwargs) -> DeclusteringResult:
+        model = _make_result_model(**kwargs)
+        return DeclusteringResult(context=MagicMock(), model=model)
+
+    def test_message(self):
+        r = self._result()
+        self.assertEqual(r.message, "Declustering completed successfully.")
+
+    def test_target_name(self):
+        r = self._result(target_name="Samples")
+        self.assertEqual(r.target_name, "Samples")
+
+    def test_target_reference(self):
+        r = self._result()
+        self.assertEqual(r.target_reference, TARGET_URL)
+
+    def test_attribute_name(self):
+        r = self._result(attr_name="decluster_wt")
+        self.assertEqual(r.attribute_name, "decluster_wt")
+
+    def test_display_name(self):
+        self.assertEqual(DeclusteringResult.TASK_DISPLAY_NAME, "Declustering")
+
+    def test_str_contains_key_info(self):
+        r = self._result(target_name="Samples", attr_name="weights")
+        s = str(r)
+        self.assertIn("Declustering", s)
+        self.assertIn("Samples", s)
+        self.assertIn("weights", s)
+
+    def test_schema_parses_valid_id(self):
+        r = self._result()
+        self.assertEqual(r.schema.sub_classification, "pointset")
+
+
+# ---------------------------------------------------------------------------
+# Runner end-to-end tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_declustering_context():
+    mock_connector = MagicMock()
+    mock_context = MagicMock()
+    mock_context.get_connector.return_value = mock_connector
+    mock_context.get_org_id.return_value = "test-org-id"
+    return mock_context, mock_connector
+
+
+def _mock_declustering_job():
+    mock_job = AsyncMock()
+    mock_job.wait_for_results.return_value = _make_result_model()
+    return mock_job
+
+
+class TestDeclusteringRunnerExecution(IsolatedAsyncioTestCase):
+    async def test_runner_submits_job_and_returns_result(self):
+        mock_context, _ = _mock_declustering_context()
+        params = DeclusteringParameters(
+            source=POINTSET_URL,
+            grid=GRID_URL,
+            target=Target(object=TARGET_URL, attribute=CreateAttribute(name="weights")),
+            neighborhood=_search(),
+        )
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=_mock_declustering_job(),
+        ):
+            result = await DeclusteringRunner(mock_context, params)
+
+        self.assertIsInstance(result, DeclusteringResult)
+        self.assertEqual(result.target_name, "MyPointset")
+
+    async def test_runner_knn_mode_sends_null_power(self):
+        mock_context, _ = _mock_declustering_context()
+        params = DeclusteringParameters(
+            source=POINTSET_URL,
+            grid=GRID_URL,
+            target=Target(object=TARGET_URL, attribute=CreateAttribute(name="weights")),
+            neighborhood=_search(),
+            power=None,
+        )
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=_mock_declustering_job(),
+        ) as mock_submit:
+            await DeclusteringRunner(mock_context, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        submitted_params = kwargs.get("parameters", {})
+        self.assertIn("power", submitted_params)
+        self.assertIsNone(submitted_params["power"])


### PR DESCRIPTION
## Summary

Adds an SDK client for the unified **declustering** compute task (`geostatistics/declustering`).

### Design

The task computes grid-based declustering weights by measuring each sample's influence on evaluation locations. Two estimation modes are exposed as module-level factory functions:

- **`idw(source, grid, target, neighborhood, *, power=2.0)`** — inverse-distance weighting; higher `power` gives nearer samples more weight
- **`knn(source, grid, target, neighborhood)`** — arithmetic-mean nearest-neighbour (equal weights); typically paired with `max_samples=1`

Both return a `DeclusteringParameters` instance, dispatched to `DeclusteringRunner` via the `TaskRegistry`.

A `@model_serializer` ensures `power=None` is serialised as `null` (not omitted) under `exclude_none=True`, so the server correctly interprets KNN mode.

### Changes

- **New**: `declustering.py` — `DeclusteringParameters`, `DeclusteringResult`, `DeclusteringRunner`, factory functions `idw()` and `knn()`
- **New**: `test_declustering_tasks.py` — comprehensive test suite (registration, serialization, result handling, runner execution, factory functions)
- **Updated**: `geostatistics/__init__.py` — import and re-export declustering module
- **Updated**: `tasks/__init__.py` — re-export `DeclusteringResult`, add to `__all__`

### Companion PR

Backend task implementation: https://github.com/seequent/core-compute-tasks/pull/737

## Checklist
- [x] I have read the contributing guide and the code of conduct
- [x] Follows existing SDK patterns (Parameters, TaskRunner, Result wrapper)
- [x] Factory functions `idw()` / `knn()` for clear mode selection
- [x] `model_serializer` preserves `power: null` for KNN mode under `exclude_none=True`
- [x] Tests pass (`218 passed`)
- [x] Linting passes (ruff)