### PR TITLE
fix: remove lineage property from block model API models

### DIFF
--- a/packages/evo-blockmodels/pyproject.toml
+++ b/packages/evo-blockmodels/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-blockmodels"
 description = "Python SDK for using the Seequent Evo Geoscience Block Model API"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-blockmodels/src/evo/blockmodels/endpoints/models.py
+++ b/packages/evo-blockmodels/src/evo/blockmodels/endpoints/models.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import (
@@ -187,31 +187,6 @@ class JobStatus(Enum):
     PROCESSING = "PROCESSING"
     COMPLETE = "COMPLETE"
     FAILED = "FAILED"
-
-
-class LineageV100RuneventInputdataset(CustomBaseModel):
-    facets: Annotated[dict[str, Any] | None, Field(title="Facets")] = None
-    inputFacets: Annotated[dict[str, Any] | None, Field(title="Inputfacets")] = None
-    name: Annotated[StrictStr, Field(title="Name")]
-    namespace: Annotated[StrictStr, Field(title="Namespace")]
-
-
-class LineageV100RuneventJob(CustomBaseModel):
-    facets: Annotated[dict[str, Any] | None, Field(title="Facets")] = None
-    name: Annotated[StrictStr, Field(title="Name")]
-    namespace: Annotated[StrictStr, Field(title="Namespace")]
-
-
-class LineageV100RuneventOutputdataset(CustomBaseModel):
-    facets: Annotated[dict[str, Any] | None, Field(title="Facets")] = None
-    name: Annotated[StrictStr, Field(title="Name")]
-    namespace: Annotated[StrictStr, Field(title="Namespace")]
-    outputFacets: Annotated[dict[str, Any] | None, Field(title="Outputfacets")] = None
-
-
-class LineageV100RuneventRun(CustomBaseModel):
-    facets: Annotated[dict[str, Any] | None, Field(title="Facets")] = None
-    runId: Annotated[UUID, Field(title="Runid")]
 
 
 class Location(CustomBaseModel):
@@ -904,17 +879,6 @@ class DeltaRequestData(CustomBaseModel):
     """
     If there are changes, whether to return details about such changes or not.
     """
-
-
-class LineageV100Runevent(CustomBaseModel):
-    eventTime: Annotated[StrictStr, Field(title="Eventtime")]
-    eventType: Annotated[StrictStr | None, Field(title="Eventtype")] = None
-    inputs: Annotated[list[LineageV100RuneventInputdataset] | None, Field(title="Inputs")] = None
-    job: LineageV100RuneventJob
-    outputs: Annotated[list[LineageV100RuneventOutputdataset] | None, Field(title="Outputs")] = None
-    producer: Annotated[StrictStr, Field(title="Producer")]
-    run: LineageV100RuneventRun
-    schemaURL: Annotated[StrictStr, Field(title="Schemaurl")]
 
 
 class Mapping(CustomBaseModel):
@@ -1855,16 +1819,6 @@ class JobResponse(CustomBaseModel):
     """
 
 
-class LineageV100Input(CustomBaseModel):
-    events: Annotated[list[LineageV100Runevent], Field(title="Events")]
-    self_link: Annotated[StrictStr | None, Field(title="Self Link")] = None
-
-
-class LineageV100Output(CustomBaseModel):
-    events: Annotated[list[LineageV100Runevent], Field(title="Events")]
-    self_link: Annotated[StrictStr | None, Field(title="Self Link")] = None
-
-
 class PaginatedResponseWithUnitsReportSpecificationWithLastRunInfo(CustomBaseModel):
     count: Annotated[StrictInt, Field(title="Count")]
     """
@@ -2130,10 +2084,6 @@ class UpdateBlockModel(CustomBaseModel):
     with missing sub-blocks will fill the missing sub-blocks with data from the parent block.
 
     """
-    lineage: LineageV100Input | None = None
-    """
-    Lineage of the block model
-    """
     name: Annotated[StrictStr | None, Field(max_length=100, min_length=3, title="Name")] = None
     """
     Name of the block model. This may not contain `/` nor `\\`. If the name is changed, leading and trailing whitespace will be automatically removed.
@@ -2212,10 +2162,6 @@ class UpdateDataLiteInput(CustomBaseModel):
         InputOptionsParquet | InputOptionsCSV | InputOptionsDatamine | None,
         Field(discriminator="file_format", title="Input Options"),
     ] = None
-    lineage: LineageV100Input | None = None
-    """
-    Lineage of the block model update
-    """
     update_type: UpdateType = "merge"
     """
     
@@ -2252,10 +2198,6 @@ class UpdateDataLiteOutput(CustomBaseModel):
         InputOptionsParquet | InputOptionsCSV | InputOptionsDatamine | None,
         Field(discriminator="file_format", title="Input Options"),
     ] = None
-    lineage: LineageV100Output | None = None
-    """
-    Lineage of the block model update
-    """
     update_type: UpdateType = "merge"
     """
     
@@ -2289,10 +2231,6 @@ class UpdateDataWithVersion(CustomBaseModel):
         - `update_metadata` is allowed, but only when the target columns are being updated as part of the `update` operation, and only when there are no columns being renamed.
         - If `update_type` is set to `merge`, then all sub-blocks within a parent block must be provided.
 
-    """
-    lineage: LineageV100Output | None = None
-    """
-    Lineage of the block model update
     """
     update_type: UpdateType = "merge"
     """
@@ -2432,10 +2370,6 @@ class CreateData(CustomBaseModel):
     If this flag is `true`, then updates to a fully subblocked-model with `update_type`=`merge`, and `geometry_change`=`true`
     with missing sub-blocks will fill the missing sub-blocks with data from the parent block.
 
-    """
-    lineage: LineageV100Input | None = None
-    """
-    Lineage of the block model
     """
     model_origin: Location
     name: Annotated[StrictStr, Field(title="Name")]

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "evo-blockmodels"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/evo-blockmodels" }
 dependencies = [
     { name = "evo-sdk-common" },
@@ -1226,7 +1226,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.5.22"
+version = "0.5.23"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
## Description

Remove the `lineage` property from block model API models, so the SDK no longer sends it to the BMS API. This is in preparation for publishing lineage events via the Lineage API instead.

**Changes:**
- Removed `lineage` field from request models: `CreateData`, `UpdateBlockModel`, `UpdateDataLiteInput`
- Removed `lineage` field from response models: `UpdateDataLiteOutput`, `UpdateDataWithVersion`
- Removed all lineage type definitions: `LineageV100Input`, `LineageV100Output`, `LineageV100Runevent`, `LineageV100RuneventInputdataset`, `LineageV100RuneventJob`, `LineageV100RuneventOutputdataset`, `LineageV100RuneventRun`
- Removed unused `Any` import that was only used by the deleted lineage classes
- Bumped `evo-blockmodels` version to `0.4.2`

## Checklist

- [x] I have read the contributing guide and the code of conduct