### PR TITLE
PR

### DIFF
--- a/packages/evo-sdk-common/src/evo/common/data.py
+++ b/packages/evo-sdk-common/src/evo/common/data.py
@@ -238,7 +238,7 @@ class ResourceMetadata(ABC):
         pass
 
 
-_Metadata = TypeVar("_Metadata", bound=ResourceMetadata)
+_Metadata = TypeVar("_Metadata")
 
 
 class Page(Sequence[_Metadata]):

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -203,7 +203,7 @@ class WorkspaceAPIClient:
             deleted=deleted,
             filter_user_id=filter_user_id,
         )
-        page_read_coroutines = []
+        page_read_coroutines: list[Awaitable[Page[Workspace]]] = []
 
         for i in range(offset + limit, first_page.total, limit):
             page_read_coroutines.append(self.list_workspaces(
@@ -222,6 +222,8 @@ class WorkspaceAPIClient:
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
         return sorted(workspaces, key=lambda x: x.display_name)
+
+
 
     async def list_workspaces_summary(
         self,

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -11,7 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+import asyncio
+from typing import Literal, TypeAlias, Awaitable
 from uuid import UUID
 
 from pydantic import ValidationError
@@ -186,16 +187,27 @@ class WorkspaceAPIClient:
         deleted: bool | None = None,
         filter_user_id: UUID | None = None,
     ) -> list[Workspace]:
-        workspaces: list[Workspace] = []
         if offset is None:
             offset = 0
         if limit is None:
             limit = 50
 
-        while True:
-            workspace_page = await self.list_workspaces(
-                limit=limit,
-                offset=offset,
+        first_page = await self.list_workspaces(
+            limit=limit,
+            offset=offset,
+            order_by=order_by,
+            filter_created_by=filter_created_by,
+            created_at=created_at,
+            updated_at=updated_at,
+            name=name,
+            deleted=deleted,
+            filter_user_id=filter_user_id,
+        )
+        page_read_coroutines = []
+
+        for i in range(offset + limit, first_page.total, limit):
+            page_read_coroutines.append(self.list_workspaces(
+                limit=limit, offset=i,
                 order_by=order_by,
                 filter_created_by=filter_created_by,
                 created_at=created_at,
@@ -203,11 +215,11 @@ class WorkspaceAPIClient:
                 name=name,
                 deleted=deleted,
                 filter_user_id=filter_user_id,
-            )
-            workspaces += workspace_page.items()
-            offset += limit
-            if offset >= workspace_page.total:
-                break
+            ))
+
+
+        remaining_pages = await asyncio.gather(*page_read_coroutines)
+        workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
         return sorted(workspaces, key=lambda x: x.display_name)
 


### PR DESCRIPTION

## Description

   Fixes two issues raised by Bill Johnson (CENPLAT-33794):

   1. Removed `bound=ResourceMetadata` from `_Metadata` TypeVar in `Page`. The bound was incorrectly restrictive — `Page` is a generic container that never calls any `ResourceMetadata` methods on its items. This fixes the    
  type error with `Page[Workspace]`.

   2. Refactored `list_all_workspaces` to use `asyncio.gather` for concurrent page fetching instead of a sequential while loop, improving performance when multiple pages exist.

   ## Checklist

   - [x] I have read the contributing guide and the code of conduct
