### PR TITLE
Fix/page type bound and asyncio gather

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.23"
+version = "0.5.24"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/data.py
+++ b/packages/evo-sdk-common/src/evo/common/data.py
@@ -238,17 +238,17 @@ class ResourceMetadata(ABC):
         pass
 
 
-_Metadata = TypeVar("_Metadata")
+T = TypeVar("T")
 
 
-class Page(Sequence[_Metadata]):
+class Page(Sequence[T]):
     """A page of resource metadata from a paginated response.
 
     This type exposes paginated metadata from an API response, including the offset, limit, and total number of items.
     The contained items are the actual metadata from the response.
     """
 
-    def __init__(self, *, offset: int, limit: int, total: int, items: Sequence[_Metadata]) -> None:
+    def __init__(self, *, offset: int, limit: int, total: int, items: Sequence[T]) -> None:
         self._offset = offset
         self._limit = limit
         self._total = total
@@ -278,7 +278,7 @@ class Page(Sequence[_Metadata]):
         """The total number of items that are available, as reported by the API."""
         return self._total
 
-    def items(self) -> list[_Metadata]:
+    def items(self) -> list[T]:
         """Get the items that are in the page.
 
         Items are copied to prevent modification of the original items.
@@ -288,12 +288,12 @@ class Page(Sequence[_Metadata]):
         return [copy.deepcopy(item) for item in self._items]
 
     @overload
-    def __getitem__(self, key: int) -> _Metadata: ...
+    def __getitem__(self, key: int) -> T: ...
 
     @overload
-    def __getitem__(self, key: slice) -> list[_Metadata]: ...
+    def __getitem__(self, key: slice) -> list[T]: ...
 
-    def __getitem__(self, key: int | slice) -> _Metadata | list[_Metadata]:
+    def __getitem__(self, key: int | slice) -> T | list[T]:
         """Get an item or items from the page.
 
         If the key is an integer, the item at that index is returned. If the key is a slice, a list of items in the

--- a/packages/evo-sdk-common/src/evo/common/data.py
+++ b/packages/evo-sdk-common/src/evo/common/data.py
@@ -238,7 +238,7 @@ class ResourceMetadata(ABC):
         pass
 
 
-_Metadata = TypeVar("_Metadata", bound=ResourceMetadata)
+_Metadata = TypeVar("_Metadata")
 
 
 class Page(Sequence[_Metadata]):

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -203,7 +203,7 @@ class WorkspaceAPIClient:
             deleted=deleted,
             filter_user_id=filter_user_id,
         )
-        page_read_coroutines = []
+        page_read_coroutines: list[Awaitable[Page[Workspace]]] = []
 
         for i in range(offset + limit, first_page.total, limit):
             page_read_coroutines.append(self.list_workspaces(
@@ -222,6 +222,8 @@ class WorkspaceAPIClient:
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
         return sorted(workspaces, key=lambda x: x.display_name)
+
+
 
     async def list_workspaces_summary(
         self,

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Literal, TypeAlias, Awaitable
+from typing import Awaitable, Literal, TypeAlias
 from uuid import UUID
 
 from pydantic import ValidationError

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -179,7 +179,9 @@ class WorkspaceAPIClient:
         self,
         limit: int | None = None,
         offset: int | None = None,
-        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = None,
+        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = {
+            WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc
+        },
         filter_created_by: UUID | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -179,7 +179,7 @@ class WorkspaceAPIClient:
         self,
         limit: int | None = None,
         offset: int | None = None,
-            order_by=None,
+        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = None,
         filter_created_by: UUID | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -11,7 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+import asyncio
+from typing import Literal, TypeAlias, Awaitable
 from uuid import UUID
 
 from pydantic import ValidationError
@@ -186,16 +187,27 @@ class WorkspaceAPIClient:
         deleted: bool | None = None,
         filter_user_id: UUID | None = None,
     ) -> list[Workspace]:
-        workspaces: list[Workspace] = []
         if offset is None:
             offset = 0
         if limit is None:
             limit = 50
 
-        while True:
-            workspace_page = await self.list_workspaces(
-                limit=limit,
-                offset=offset,
+        first_page = await self.list_workspaces(
+            limit=limit,
+            offset=offset,
+            order_by=order_by,
+            filter_created_by=filter_created_by,
+            created_at=created_at,
+            updated_at=updated_at,
+            name=name,
+            deleted=deleted,
+            filter_user_id=filter_user_id,
+        )
+        page_read_coroutines = []
+
+        for i in range(offset + limit, first_page.total, limit):
+            page_read_coroutines.append(self.list_workspaces(
+                limit=limit, offset=i,
                 order_by=order_by,
                 filter_created_by=filter_created_by,
                 created_at=created_at,
@@ -203,11 +215,11 @@ class WorkspaceAPIClient:
                 name=name,
                 deleted=deleted,
                 filter_user_id=filter_user_id,
-            )
-            workspaces += workspace_page.items()
-            offset += limit
-            if offset >= workspace_page.total:
-                break
+            ))
+
+
+        remaining_pages = await asyncio.gather(*page_read_coroutines)
+        workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
         return sorted(workspaces, key=lambda x: x.display_name)
 

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -221,8 +221,10 @@ class WorkspaceAPIClient:
         remaining_pages = await asyncio.gather(*page_read_coroutines)
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
-        # Note: this sort overrides any order_by passed to this method. This was here before
-        return sorted(workspaces, key=lambda x: x.display_name)
+        if order_by is None:
+            return sorted(workspaces, key=lambda ws: ws.display_name)
+        return workspaces
+
 
 
 

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -179,9 +179,7 @@ class WorkspaceAPIClient:
         self,
         limit: int | None = None,
         offset: int | None = None,
-        order_by: dict[WorkspaceOrderByEnum, OrderByOperatorEnum] | None = {
-            WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc
-        },
+            order_by=None,
         filter_created_by: UUID | None = None,
         created_at: str | None = None,
         updated_at: str | None = None,
@@ -189,6 +187,10 @@ class WorkspaceAPIClient:
         deleted: bool | None = None,
         filter_user_id: UUID | None = None,
     ) -> list[Workspace]:
+        if order_by is None:
+            order_by = {
+                WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc
+            }
         if offset is None:
             offset = 0
         if limit is None:

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -217,12 +217,9 @@ class WorkspaceAPIClient:
                 filter_user_id=filter_user_id,
             ))
 
-
         remaining_pages = await asyncio.gather(*page_read_coroutines)
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
-        if order_by is None:
-            return sorted(workspaces, key=lambda ws: ws.display_name)
         return workspaces
 
 

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -188,9 +188,7 @@ class WorkspaceAPIClient:
         filter_user_id: UUID | None = None,
     ) -> list[Workspace]:
         if order_by is None:
-            order_by = {
-                WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc
-            }
+            order_by = {WorkspaceOrderByEnum.name: OrderByOperatorEnum.asc}
         if offset is None:
             offset = 0
         if limit is None:
@@ -210,24 +208,24 @@ class WorkspaceAPIClient:
         page_read_coroutines: list[Awaitable[Page[Workspace]]] = []
 
         for i in range(offset + limit, first_page.total, limit):
-            page_read_coroutines.append(self.list_workspaces(
-                limit=limit, offset=i,
-                order_by=order_by,
-                filter_created_by=filter_created_by,
-                created_at=created_at,
-                updated_at=updated_at,
-                name=name,
-                deleted=deleted,
-                filter_user_id=filter_user_id,
-            ))
+            page_read_coroutines.append(
+                self.list_workspaces(
+                    limit=limit,
+                    offset=i,
+                    order_by=order_by,
+                    filter_created_by=filter_created_by,
+                    created_at=created_at,
+                    updated_at=updated_at,
+                    name=name,
+                    deleted=deleted,
+                    filter_user_id=filter_user_id,
+                )
+            )
 
         remaining_pages = await asyncio.gather(*page_read_coroutines)
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
         return workspaces
-
-
-
 
     async def list_workspaces_summary(
         self,

--- a/packages/evo-sdk-common/src/evo/workspaces/client.py
+++ b/packages/evo-sdk-common/src/evo/workspaces/client.py
@@ -221,6 +221,7 @@ class WorkspaceAPIClient:
         remaining_pages = await asyncio.gather(*page_read_coroutines)
         workspaces = first_page.items() + [ws for page in remaining_pages for ws in page.items()]
 
+        # Note: this sort overrides any order_by passed to this method. This was here before
         return sorted(workspaces, key=lambda x: x.display_name)
 
 

--- a/packages/evo-sdk-common/tests/workspaces/test_endpoints/test_workspace.py
+++ b/packages/evo-sdk-common/tests/workspaces/test_endpoints/test_workspace.py
@@ -176,43 +176,12 @@ class TestWorkspaceClientWorkspaceEndpoints(TestWithConnector):
         self.assertEqual(2, self.transport.request.call_count, "Two requests should be made.")
         self.assert_any_request_made(
             method=RequestMethod.GET,
-            path=f"{BASE_PATH}/workspaces?limit=2&offset=0",
+            path=f"{BASE_PATH}/workspaces?limit=2&offset=0&order_by=asc%3Aname",
             headers=TestHTTPHeaderDict({"Accept": "application/json"}),
         )
         self.assert_any_request_made(
             method=RequestMethod.GET,
-            path=f"{BASE_PATH}/workspaces?limit=2&offset=2",
-            headers=TestHTTPHeaderDict({"Accept": "application/json"}),
-        )
-        self.assertEqual(expected_workspaces, actual_workspaces)
-
-    async def test_list_workspaces_sorted_by_display_name(self) -> None:
-        content_0 = load_test_data("list_workspaces_0.json")
-        content_1 = load_test_data("list_workspaces_1.json")
-
-        # Shuffle the workspaces in the response content.
-        results_0: list = content_0["results"]
-        results_1: list = content_1["results"]
-        results_0.insert(2, results_1.pop(0))
-        results_1.insert(0, results_0.pop(0))
-
-        responses = [
-            MockResponse(status_code=200, content=json.dumps(content_0), headers={"Content-Type": "application/json"}),
-            MockResponse(status_code=200, content=json.dumps(content_1), headers={"Content-Type": "application/json"}),
-        ]
-        self.transport.request.side_effect = responses
-        expected_workspaces = [TEST_WORKSPACE_A, TEST_WORKSPACE_B, TEST_WORKSPACE_C]
-        actual_workspaces = await self.workspace_client.list_all_workspaces(limit=2)
-
-        self.assertEqual(2, self.transport.request.call_count, "Two requests should be made.")
-        self.assert_any_request_made(
-            method=RequestMethod.GET,
-            path=f"{BASE_PATH}/workspaces?limit=2&offset=0",
-            headers=TestHTTPHeaderDict({"Accept": "application/json"}),
-        )
-        self.assert_any_request_made(
-            method=RequestMethod.GET,
-            path=f"{BASE_PATH}/workspaces?limit=2&offset=2",
+            path=f"{BASE_PATH}/workspaces?limit=2&offset=2&order_by=asc%3Aname",
             headers=TestHTTPHeaderDict({"Accept": "application/json"}),
         )
         self.assertEqual(expected_workspaces, actual_workspaces)


### PR DESCRIPTION

## Description

   Two fixes for the workspaces SDK:

   **1. Fix `Page` type bound**

   Removed `bound=ResourceMetadata` from the `_Metadata` TypeVar in `Page`. The bound was incorrectly
   restrictive,. This caused type errors when using `Page[Workspace]` since `Workspace` does not inherit
  from `ResourceMetadata`.

   **2. Refactor `list_all_workspaces` to use `asyncio.gather`**

   Replaced the sequential while loop with `asyncio.gather` to fetch all remaining pages concurrently
   after the first page. This reduces total fetch time when multiple pages exist.

   ## Checklist

   - [x] I have read the contributing guide and the code of conduct