### PR TITLE
Typed downhole collection

### DIFF
--- a/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
+++ b/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "7",
    "metadata": {},
    "source": [
     "## 4. Create the Object in Evo\n",
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c396bc242dc37d7a",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
+++ b/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Simplified Downhole Collection\n",
+    "\n",
+    "This notebook demonstrates how to create a **`DownholeCollection`** geoscience object using the **typed objects API** (`evo.objects.typed`).\n",
+    "\n",
+    "A downhole collection describes a set of drill holes via:\n",
+    "- a **path** table (the geometry of each hole as `distance`/`azimuth`/`dip` steps),\n",
+    "- a **holes** table that slices the path into individual holes (`hole_index`/`offset`/`count`),\n",
+    "- a **properties** table with the collar location and depths per hole (`hole_id`, `x`, `y`, `z`, `final`, `target`, `current`),\n",
+    "- zero or more **collections** of downhole measurements (here, a `DistanceCollection`).\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "You must have a Seequent account with the Evo entitlement. You'll need:\n",
+    "- The client ID of your Evo application\n",
+    "- The callback/redirect URL of your Evo application\n",
+    "\n",
+    "To obtain these credentials, refer to the [Apps and tokens guide](https://developer.seequent.com/docs/guides/getting-started/apps-and-tokens)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## 1. Authentication\n",
+    "\n",
+    "First, we authenticate using the `ServiceManagerWidget`. This handles OAuth login and workspace selection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "from evo.notebooks import ServiceManagerWidget\n",
+    "\n",
+    "# Replace with your Evo app credentials\n",
+    "client_id = \"<your-client-id>\"\n",
+    "redirect_url = \"<your-redirect-url>\"\n",
+    "\n",
+    "manager = await ServiceManagerWidget.with_auth_code(\n",
+    "    client_id=client_id,\n",
+    "    redirect_url=redirect_url,\n",
+    "    cache_location=\"./notebook-data\",\n",
+    ").login()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## 2. Load the Widgets Extension\n",
+    "\n",
+    "The `evo.widgets` extension enables rich HTML rendering of Evo objects in Jupyter notebooks. After loading, objects will automatically display with formatted tables and clickable links."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "%load_ext evo.widgets"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## 3. Build the Downhole Collection\n",
+    "\n",
+    "This creates a downhole collection with two holes. See `DownholeCollectionData` to understand what all the data fields represent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "from datetime import date, datetime, timezone\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from evo.objects.typed.downhole_collection import DownholeCollectionData, DistanceCollection\n",
+    "\n",
+    "# Concatenated path table representing two holes: hole 0 has 4 rows, hole 1 has 3 rows. It has one custom attribute \"attr\".\n",
+    "path = pd.DataFrame(\n",
+    "    {\n",
+    "        \"distance\": [0.0, 10.0, 20.0, 30.0, 0.0, 15.0, 30.0],\n",
+    "        \"azimuth\": [0.0, 0.0, 0.0, 0.0, 90.0, 90.0, 90.0],\n",
+    "        \"dip\": [90.0, 90.0, 90.0, 90.0, 45.0, 45.0, 45.0],\n",
+    "        \"attr\": [\"a\", \"b\", \"a\", \"c\", \"c\", \"c\", \"c\"],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# Map each hole to a contiguous slice of the path table. There are two rows, which means there are two holes.\n",
+    "# Note the `astype`. The columns must have those exact types.\n",
+    "holes = pd.DataFrame(\n",
+    "    {\n",
+    "        \"hole_index\": [0, 1],\n",
+    "        \"offset\": [0, 4],\n",
+    "        \"count\": [4, 3],\n",
+    "    }\n",
+    ").astype({'hole_index': np.int32, 'offset': np.uint64, 'count': np.uint64})\n",
+    "\n",
+    "# There are two custom attributes for each hole. This is optional.\n",
+    "attributes = pd.DataFrame(\n",
+    "    {\n",
+    "        \"attr_str\": [\"a\", \"b\"],\n",
+    "        \"attr_int\": [1, 2],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# These are mandatory per-hole properties.\n",
+    "properties = pd.DataFrame(\n",
+    "    {\n",
+    "        \"hole_id\": [\"H001\", \"H002\"],\n",
+    "        \"x\": [100.0, 200.0],\n",
+    "        \"y\": [150.0, 300.0],\n",
+    "        \"z\": [0.0, 50.0],\n",
+    "        \"final\": [30.0, 30.0],\n",
+    "        \"target\": [25.0, 25.0],\n",
+    "        \"current\": [30.0, 28.0],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# This represents a collection of surveyed data, e.g. depth measurements.\n",
+    "# Note the `astype` for the `holes` argument. The columns must have those exact types.\n",
+    "# This collection has three custom attributes, in addition to the depths.\n",
+    "collection = DistanceCollection(\n",
+    "    name=\"collection1\",\n",
+    "    collection_type=\"distance\",\n",
+    "    holes=pd.DataFrame(\n",
+    "        {\n",
+    "            \"hole_index\": [0],\n",
+    "            \"offset\": [0],\n",
+    "            \"count\": [4],\n",
+    "        }\n",
+    "    ).astype({'hole_index': np.int32, 'offset': np.uint64, 'count': np.uint64}),\n",
+    "    distance_table=pd.DataFrame(\n",
+    "        {\n",
+    "            \"distance\": [0.0, 10.0, 20.0, 30.0],\n",
+    "            \"attr_str\": [\"a\", \"b\", \"a\", \"c\"],\n",
+    "            \"attr_dt\": [date(2000, 1, 1), date(2000, 1, 2), date(2000, 1, 3), date(2000, 1, 4)],\n",
+    "            \"attr_num\": [1.1, 2.2, 3.3, 4.4],\n",
+    "        }\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "dhc_data = DownholeCollectionData(\n",
+    "    name=f\"Example DHC {datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}\",\n",
+    "    description=\"A downhole collection created with the typed objects API\",\n",
+    "    tags={\"site\": \"alpha\", \"status\": \"active\"},\n",
+    "    path=path,\n",
+    "    holes=holes,\n",
+    "    properties=properties,\n",
+    "    attributes=attributes,\n",
+    "    collections=[collection],\n",
+    "    distance_unit=\"m\",\n",
+    "    desurvey=\"trench\",\n",
+    ")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## 4. Create the Object in Evo\n",
+    "\n",
+    "`DownholeCollection.create` uploads the data tables and publishes the geoscience object. Displaying the returned object renders a rich HTML summary with links to the Evo Portal and Viewer."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "from evo.objects.typed.downhole_collection import DownholeCollection\n",
+    "\n",
+    "dhc = await DownholeCollection.create(manager, dhc_data)\n",
+    "dhc"
+   ],
+   "id": "c396bc242dc37d7a",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
+++ b/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
@@ -116,7 +116,7 @@
     "        \"offset\": [0, 4],\n",
     "        \"count\": [4, 3],\n",
     "    }\n",
-    ").astype({'hole_index': np.int32, 'offset': np.uint64, 'count': np.uint64})\n",
+    ").astype({\"hole_index\": np.int32, \"offset\": np.uint64, \"count\": np.uint64})\n",
     "\n",
     "# There are two custom attributes for each hole. This is optional.\n",
     "attributes = pd.DataFrame(\n",
@@ -151,7 +151,7 @@
     "            \"offset\": [0],\n",
     "            \"count\": [4],\n",
     "        }\n",
-    "    ).astype({'hole_index': np.int32, 'offset': np.uint64, 'count': np.uint64}),\n",
+    "    ).astype({\"hole_index\": np.int32, \"offset\": np.uint64, \"count\": np.uint64}),\n",
     "    distance_table=pd.DataFrame(\n",
     "        {\n",
     "            \"distance\": [0.0, 10.0, 20.0, 30.0],\n",
@@ -173,7 +173,7 @@
     "    collections=[collection],\n",
     "    distance_unit=\"m\",\n",
     "    desurvey=\"trench\",\n",
-    ")\n"
+    ")"
    ]
   },
   {

--- a/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
+++ b/code-samples/geoscience-objects/simplified-object-interactions/create-downhole-collection.ipynb
@@ -36,8 +36,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "2",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from evo.notebooks import ServiceManagerWidget\n",
     "\n",
@@ -50,9 +52,7 @@
     "    redirect_url=redirect_url,\n",
     "    cache_location=\"./notebook-data\",\n",
     ").login()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -66,13 +66,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "4",
    "metadata": {},
+   "outputs": [],
    "source": [
     "%load_ext evo.widgets"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -86,15 +86,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "6",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from datetime import date, datetime, timezone\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "from evo.objects.typed.downhole_collection import DownholeCollectionData, DistanceCollection\n",
+    "from evo.objects.typed.downhole_collection import DistanceCollection, DownholeCollectionData\n",
     "\n",
     "# Concatenated path table representing two holes: hole 0 has 4 rows, hole 1 has 3 rows. It has one custom attribute \"attr\".\n",
     "path = pd.DataFrame(\n",
@@ -172,9 +174,7 @@
     "    distance_unit=\"m\",\n",
     "    desurvey=\"trench\",\n",
     ")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -187,17 +187,17 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c396bc242dc37d7a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from evo.objects.typed.downhole_collection import DownholeCollection\n",
     "\n",
     "dhc = await DownholeCollection.create(manager, dhc_data)\n",
     "dhc"
-   ],
-   "id": "c396bc242dc37d7a",
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/mkdocs/site/packages/evo-objects/typed-objects/attributes/Attributes.html
+++ b/mkdocs/site/packages/evo-objects/typed-objects/attributes/Attributes.html
@@ -90,6 +90,17 @@
 
 
         <p>A collection of Geoscience Object Attributes</p>
+<p>The data source is a pandas DataFrame. If the DataFrame has attribute descriptions attached
+to it, then they will be used to populate the schema's "attribute_description" fields. The
+attribute descriptions are attached to the DataFrame's <code>attrs</code> attribute.</p>
+<blockquote>
+<blockquote>
+<blockquote>
+<p>df.attrs
+{'attribute_description': {<column names>:  <AttributeDescription>}, ...}</p>
+</blockquote>
+</blockquote>
+</blockquote>
 
 
 

--- a/mkdocs/site/packages/evo-objects/typed-objects/block-model-ref/RegularBlockModelData.html
+++ b/mkdocs/site/packages/evo-objects/typed-objects/block-model-ref/RegularBlockModelData.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../pointset/Locations.html" class="nav-link">
+                                <a rel="next" href="../downhole-collection/DownholeCollection.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-objects/typed-objects/pointset/Locations.html
+++ b/mkdocs/site/packages/evo-objects/typed-objects/pointset/Locations.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../block-model-ref/RegularBlockModelData.html" class="nav-link">
+                                <a rel="prev" href="../downhole-collection/DownholeCollectionData.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.4.3"
+version = "0.5.0"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/src/evo/objects/typed/__init__.py
+++ b/packages/evo-objects/src/evo/objects/typed/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/packages/evo-objects/src/evo/objects/typed/__init__.py
+++ b/packages/evo-objects/src/evo/objects/typed/__init__.py
@@ -22,6 +22,7 @@ from .base import BaseObject, object_from_path, object_from_reference, object_fr
 from .block_model_ref import (
     BlockModel,
 )
+from .downhole_collection import DownholeCollection, DownholeCollectionData
 from .pointset import (
     Locations,
     PointSet,
@@ -80,6 +81,8 @@ __all__ = [
     "BoundingBox",
     "CoordinateReferenceSystem",
     "CubicStructure",
+    "DownholeCollection",
+    "DownholeCollectionData",
     "Ellipsoid",
     "EllipsoidRanges",
     "EpsgCode",

--- a/packages/evo-objects/src/evo/objects/typed/_data.py
+++ b/packages/evo-objects/src/evo/objects/typed/_data.py
@@ -1,3 +1,14 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from __future__ import annotations
 
 from typing import Annotated, Any, ClassVar

--- a/packages/evo-objects/src/evo/objects/typed/_data.py
+++ b/packages/evo-objects/src/evo/objects/typed/_data.py
@@ -111,7 +111,7 @@ class DataTableAndAttributes(SchemaModel):
         if attr_df is not None:
             await self.attributes.set_attributes(attr_df, fb=fb)
         else:
-            await self.attributes.clear()
+            self.attributes.clear()
 
     def validate(self) -> None:
         """Validate that all attributes have the correct length."""

--- a/packages/evo-objects/src/evo/objects/typed/attributes.py
+++ b/packages/evo-objects/src/evo/objects/typed/attributes.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/packages/evo-objects/src/evo/objects/typed/attributes.py
+++ b/packages/evo-objects/src/evo/objects/typed/attributes.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
+import typing
 import uuid
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
@@ -23,6 +25,7 @@ from evo.common.utils import NoFeedback, iter_with_fb
 from evo.objects import DownloadedObject
 from evo.objects.utils.table_formats import (
     BOOL_ARRAY_1,
+    DATE_TIME_ARRAY,
     FLOAT_ARRAY_1,
     INTEGER_ARRAY_1_INT32,
     INTEGER_ARRAY_1_INT64,
@@ -67,6 +70,8 @@ def _infer_attribute_type_from_series(series: pd.Series) -> str:
         return "category"
     elif pd.api.types.is_string_dtype(series):
         return "string"
+    elif pd.api.types.infer_dtype(series, skipna=True) in ["date", "datetime", "datetime64"]:
+        return "date_time"
     else:
         raise UnSupportedDataTypeError(f"Unsupported dtype for attribute: {series.dtype}")
 
@@ -76,7 +81,33 @@ _attribute_table_formats = {
     "integer": [INTEGER_ARRAY_1_INT32, INTEGER_ARRAY_1_INT64],
     "bool": [BOOL_ARRAY_1],
     "string": [STRING_ARRAY],
+    "date_time": [DATE_TIME_ARRAY],
 }
+
+
+@dataclass
+class AttributeDescription:
+    discipline: str = ""
+    type: str = ""
+    unit: str | None = None
+    scale: str | None = None
+    extensions: dict[str, typing.Any] | None = None
+    tags: dict[str, str] | None = None
+
+    def to_schema(self):
+        result = {
+            "discipline": self.discipline,
+            "type": self.type,
+        }
+        if self.unit:
+            result["unit"] = self.unit
+        if self.scale:
+            result["scale"] = self.scale
+        if self.extensions:
+            result["extensions"] = self.extensions
+        if self.tags:
+            result["tags"] = self.tags
+        return result
 
 
 class Attribute(SchemaModel):
@@ -158,7 +189,7 @@ class Attribute(SchemaModel):
             table_formats = _attribute_table_formats.get(attribute_type)
             attr_doc["values"] = await data_client.upload_dataframe(df, table_format=table_formats, fb=fb)
 
-        if attribute_type in ["scalar", "integer", "category"]:
+        if attribute_type in ["scalar", "integer", "category", "date_time"]:
             attr_doc["nan_description"] = {"values": []}
 
 
@@ -203,7 +234,15 @@ class PendingAttribute:
 
 
 class Attributes(SchemaList[Attribute]):
-    """A collection of Geoscience Object Attributes"""
+    """A collection of Geoscience Object Attributes
+
+    The data source is a pandas DataFrame. If the DataFrame has attribute descriptions attached
+    to it, then they will be used to populate the schema's "attribute_description" fields. The
+    attribute descriptions are attached to the DataFrame's `attrs` attribute.
+
+    >>> df.attrs
+    {'attribute_description': {<column names>:  <AttributeDescription>}, ...}
+    """
 
     _schema_path: str | None = None
     """The full JMESPath to this attributes list within the parent object schema."""
@@ -263,7 +302,7 @@ class Attributes(SchemaList[Attribute]):
 
         for col in df.columns:
             series = df[col]
-            attribute_type = _infer_attribute_type_from_series(series)
+            attribute_type = _infer_attribute_type_from_series(df[col])
 
             attr_doc: dict[str, Any] = {
                 "name": str(col),
@@ -271,8 +310,18 @@ class Attributes(SchemaList[Attribute]):
                 "attribute_type": attribute_type,
             }
 
-            col_df = df[[col]]
+            if attribute_type == "date_time":
+                series = pd.to_datetime(series, utc=True).dt.as_unit("us")
+
+            col_df = pd.DataFrame({col: series})
             await Attribute._upload_attribute_values(attr_doc, col_df, attribute_type, data_client)
+
+            attr_desc: AttributeDescription | None = df.attrs.get("attribute_descriptions", {}).get(col)
+            if attr_desc is not None:
+                if not isinstance(attr_desc, AttributeDescription):
+                    raise TypeError("attribute description must be a AttributeDescription.")
+                if attr_desc.unit is not None:
+                    attr_doc["attribute_description"] = attr_desc.to_schema()
 
             attributes_list.append(attr_doc)
 
@@ -528,3 +577,22 @@ class BlockModelAttributes:
     def __repr__(self) -> str:
         names = [attr.name for attr in self._attributes]
         return f"BlockModelAttributes({names})"
+
+
+class Category(SchemaModel):
+    _data: Annotated[str, SchemaLocation("values.data")]
+
+    @classmethod
+    async def _data_to_schema(cls, category_table, context: IContext) -> Any:
+        data_client = get_data_client(context)
+        return await data_client.upload_category_dataframe(category_table)
+
+    async def to_dataframe(self, fb: IFeedback = NoFeedback) -> pd.DataFrame:
+        """Load a DataFrame containing values for this table.
+
+        :param fb: Optional feedback object to report download progress.
+        :return: The loaded DataFrame with values for this table.
+        """
+        if self._context.is_data_modified(self._data):
+            raise DataLoaderError("Data was modified since the object was downloaded")
+        return await self._obj.download_dataframe(self.as_dict()["values"], fb=fb)

--- a/packages/evo-objects/src/evo/objects/typed/attributes.py
+++ b/packages/evo-objects/src/evo/objects/typed/attributes.py
@@ -581,6 +581,11 @@ class BlockModelAttributes:
 
 class Category(SchemaModel):
     _data: Annotated[str, SchemaLocation("values.data")]
+    _length: Annotated[int, SchemaLocation("values.length")]
+
+    @property
+    def length(self):
+        return self._length
 
     @classmethod
     async def _data_to_schema(cls, category_table, context: IContext) -> Any:

--- a/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
+++ b/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
@@ -131,9 +131,10 @@ class DownholeCollectionData(BaseSpatialObjectData):
             raise ObjectValidationError("depths, dips, and azimuths must have same length")
 
         # Process NaNs
+        # `depths`, `dips`, and `azimuths` could be read-only views, so take copies instead of mutating
         depths = depths[~np.isnan(depths)]
-        dips[np.isnan(dips)] = 90
-        azimuths[np.isnan(azimuths)] = 0
+        dips = np.where(np.isnan(dips), 90.0, dips)
+        azimuths = np.where(np.isnan(azimuths), 0.0, azimuths)
 
         dips_rad = np.deg2rad(dips)
         azimuths_rad = np.deg2rad(azimuths)

--- a/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
+++ b/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated, Any, ClassVar, TypeAlias, TypedDict
+from typing import Annotated, Any, ClassVar, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -23,6 +23,7 @@ from evo.objects import SchemaVersion
 from evo.objects.typed._data import DataTable, DataTableAndAttributes
 from evo.objects.typed._model import DataLocation, SchemaList, SchemaLocation, SchemaModel
 from evo.objects.typed.attributes import (
+    AttributeDescription,
     Attributes,
     Category,
 )
@@ -47,11 +48,17 @@ _Z = "z"
 _COORDINATE_COLUMNS = [_X, _Y, _Z]
 
 
-HolePath: TypeAlias = pd.DataFrame
-HoleChunks: TypeAlias = pd.DataFrame
-HoleProperties: TypeAlias = pd.DataFrame
+HolePath: TypeAlias = pd.DataFrame  # [ distance | dip | azimuth | <attributes> ]
+HoleChunks: TypeAlias = pd.DataFrame  # [ hole_id | offset | count ]
+HoleProperties: TypeAlias = pd.DataFrame  # [ hole_id | final | target | current | x | y | z ]
 HoleAttributes: TypeAlias = pd.DataFrame
-Depths: TypeAlias = pd.DataFrame
+
+# If `Depths` has unit descriptions in its `DataFrame.attrs` dictionary, then those units will be used when building
+# the schema object.
+# This is the expected structure:
+#   >>> depths_df.attrs
+#   {'attribute_description': {<column names>:  <AttributeDescription>}, ...}
+Depths: TypeAlias = pd.DataFrame  # [ distance | <attributes> ]
 
 
 @dataclass
@@ -67,16 +74,17 @@ class DownholeCollectionData(BaseSpatialObjectData):
     """Data class for creating a new DownholeCollection
 
     :param name: The name of the object.
-    :param holes: A list of DataFrames representing the paths of the holes. One DataFrame per hole.
-            Mandatory columns: depth, dip, azimuth. Extra columns are treated as attributes.
+    :param holes: A DataFrame describing which parts of `path` belong to which holes.
+            Columns: hole_id, offset, count
     :param properties: DataFrame for the properties of the holes. The ith row corresponds to the ith element of `holes`.
             Mandatory columns: hole_id, final, target, current, x, y, z
     :param attributes: DataFrame for the attributes of the holes. The ith row corresponds to the ith element of `holes`.
     :param path: Dataframe of [ distance | dip | azimuth | <attributes> ]. Distance/dip/azimuth describe the geometry as
             the step since the previous row.
     :param collections: A list of `DistanceCollection` describing a table of distances with attributes.
-    :param distance_unit: The distance unit for the `path` table and the `properties` x/y/z
-    .
+    :param distance_unit: The distance unit for the `path` table and the `properties` x/y/y.
+    :param desurvey: The desurvey method appropriate for this collection.
+            Must be one of: "minimum_curvature", "balanced_tangent", "trench".
     :param coordinate_reference_system: Optional EPSG code or WKT string for the coordinate reference system.
     :param description: Optional description of the object.
     :param tags: Optional dictionary of tags for the object.
@@ -89,6 +97,7 @@ class DownholeCollectionData(BaseSpatialObjectData):
     attributes: HoleAttributes | None
     collections: list[DistanceCollection]
     distance_unit: str | None
+    desurvey: str | None
 
     def __post_init__(self):
         if self.attributes is not None and len(self.holes) != len(self.attributes):
@@ -268,7 +277,7 @@ class DistanceTableDistances(DataTableAndAttributes):
     @classmethod
     async def _data_to_schema(cls, data: pd.DataFrame, context: IContext) -> Any:
         result = await super()._data_to_schema(data, context)
-        attr_desc = data.attrs.get("attribute_descriptions", {}).get("distance")
+        attr_desc: AttributeDescription = data.attrs.get("attribute_descriptions", {}).get("distance")
         if attr_desc is not None:
             result["unit"] = attr_desc.unit
         else:
@@ -300,5 +309,6 @@ class DownholeCollection(BaseSpatialObject):
     location: Annotated[DownholeLocation, SchemaLocation("location"), DataLocation("")]
     collections: Annotated[DownholeCollectionTables, SchemaLocation("collections"), DataLocation("collections")]
     distance_unit: Annotated[str | None, SchemaLocation("distance_unit")]
+    desurvey: Annotated[str | None, SchemaLocation("desurvey")]
 
     type: ClassVar[Annotated[str, SchemaLocation("type")]] = "downhole"

--- a/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
+++ b/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
@@ -278,10 +278,9 @@ class DistanceTableDistances(DataTableAndAttributes):
     async def _data_to_schema(cls, data: pd.DataFrame, context: IContext) -> Any:
         result = await super()._data_to_schema(data, context)
         attr_desc: AttributeDescription = data.attrs.get("attribute_descriptions", {}).get("distance")
-        if attr_desc is not None:
+        if attr_desc is not None and attr_desc.unit is not None:
+            # "unit" can be missing, but it must not be `None`
             result["unit"] = attr_desc.unit
-        else:
-            result["unit"] = None
         return result
 
 

--- a/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
+++ b/packages/evo-objects/src/evo/objects/typed/downhole_collection.py
@@ -1,0 +1,304 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Any, ClassVar, TypeAlias, TypedDict
+
+import numpy as np
+import pandas as pd
+from numpy._typing import NDArray
+
+from evo.common.interfaces import IContext
+from evo.objects import SchemaVersion
+from evo.objects.typed._data import DataTable, DataTableAndAttributes
+from evo.objects.typed._model import DataLocation, SchemaList, SchemaLocation, SchemaModel
+from evo.objects.typed.attributes import (
+    Attributes,
+    Category,
+)
+from evo.objects.typed.exceptions import ObjectValidationError
+from evo.objects.typed.spatial import BaseSpatialObject, BaseSpatialObjectData
+from evo.objects.typed.types import BoundingBox
+from evo.objects.utils.table_formats import (
+    DOWNHOLE_COLLECTION_LOCATION_HOLES,
+    FLOAT_ARRAY_1,
+    FLOAT_ARRAY_3,
+    KnownTableFormat,
+)
+
+__all__ = [
+    "DownholeCollection",
+    "DownholeCollectionData",
+]
+
+_X = "x"
+_Y = "y"
+_Z = "z"
+_COORDINATE_COLUMNS = [_X, _Y, _Z]
+
+
+HolePath: TypeAlias = pd.DataFrame
+HoleChunks: TypeAlias = pd.DataFrame
+HoleProperties: TypeAlias = pd.DataFrame
+HoleAttributes: TypeAlias = pd.DataFrame
+Depths: TypeAlias = pd.DataFrame
+
+
+@dataclass
+class DistanceCollection:
+    name: str
+    holes: HoleChunks
+    distance_table: Depths
+    collection_type: str = "distance"
+
+
+@dataclass(kw_only=True, frozen=True)
+class DownholeCollectionData(BaseSpatialObjectData):
+    """Data class for creating a new DownholeCollection
+
+    :param name: The name of the object.
+    :param holes: A list of DataFrames representing the paths of the holes. One DataFrame per hole.
+            Mandatory columns: depth, dip, azimuth. Extra columns are treated as attributes.
+    :param properties: DataFrame for the properties of the holes. The ith row corresponds to the ith element of `holes`.
+            Mandatory columns: hole_id, final, target, current, x, y, z
+    :param attributes: DataFrame for the attributes of the holes. The ith row corresponds to the ith element of `holes`.
+    :param path: Dataframe of [ distance | dip | azimuth | <attributes> ]. Distance/dip/azimuth describe the geometry as
+            the step since the previous row.
+    :param collections: A list of `DistanceCollection` describing a table of distances with attributes.
+    :param distance_unit: The distance unit for the `path` table and the `properties` x/y/z
+    .
+    :param coordinate_reference_system: Optional EPSG code or WKT string for the coordinate reference system.
+    :param description: Optional description of the object.
+    :param tags: Optional dictionary of tags for the object.
+    :param extensions: Optional dictionary of extensions for the object.
+    """
+
+    path: HolePath
+    holes: HoleChunks
+    properties: HoleProperties
+    attributes: HoleAttributes | None
+    collections: list[DistanceCollection]
+    distance_unit: str | None
+
+    def __post_init__(self):
+        if self.attributes is not None and len(self.holes) != len(self.attributes):
+            raise ObjectValidationError("The number of attributes rows must match the number or holes rows")
+
+        assert self.attributes is None or len(self.holes) == len(self.attributes)
+
+    def compute_bounding_box(self) -> BoundingBox:
+        bboxes = []
+
+        for i in range(len(self.holes)):
+            offset = self.holes.iat[i, 1]
+            count = self.holes.iat[i, 2]
+            collar = tuple(self.properties.loc[i, _COORDINATE_COLUMNS])
+            path_table = self.path[offset : offset + count]
+            bboxes.append(self._compute_hole_bounding_box(path_table, collar))
+
+        return BoundingBox.combine(bboxes)
+
+    @staticmethod
+    def _compute_bounding_box_np(
+        depths: NDArray[np.float64],
+        dips: NDArray[np.float64],
+        azimuths: NDArray[np.float64],
+        offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    ) -> BoundingBox:
+        if not np.all(depths[:-1] <= depths[1:]):
+            raise ObjectValidationError("depths must be sorted")
+
+        if len(depths) != len(dips) or len(depths) != len(azimuths):
+            raise ObjectValidationError("depths, dips, and azimuths must have same length")
+
+        # Process NaNs
+        depths = depths[~np.isnan(depths)]
+        dips[np.isnan(dips)] = 90
+        azimuths[np.isnan(azimuths)] = 0
+
+        dips_rad = np.deg2rad(dips)
+        azimuths_rad = np.deg2rad(azimuths)
+
+        # Prepend 0 so `step` has the same shape as `dips` and `azimuths`, and so the first depth gets treated as the
+        # first step. The depth column might already start with 0, in which case the first step will be length 0, which
+        # is a no-op as far as the following calculation is concerned.
+        step = np.diff(depths, prepend=0.0)
+
+        dz_down = step * np.sin(dips_rad)
+        horiz = step * np.cos(dips_rad)
+
+        # Horizontal into N/E (0° = North, 90° = East)
+        dN = horiz * np.cos(azimuths_rad)
+        dE = horiz * np.sin(azimuths_rad)
+
+        # Convert to XYZ increments (Z up)
+        dX = dE
+        dY = dN
+        dZ = -dz_down
+
+        x = np.cumsum(dX)
+        y = np.cumsum(dY)
+        z = np.cumsum(dZ)
+
+        def ensure_zero(a, b):
+            return min(a, 0), max(b, 0)
+
+        x0, x1 = ensure_zero(x.min(), x.max())
+        y0, y1 = ensure_zero(y.min(), y.max())
+        z0, z1 = ensure_zero(z.min(), z.max())
+
+        return BoundingBox(
+            min_x=x0 + offset[0],
+            max_x=x1 + offset[0],
+            min_y=y0 + offset[1],
+            max_y=y1 + offset[1],
+            min_z=z0 + offset[2],
+            max_z=z1 + offset[2],
+        )
+
+    @staticmethod
+    def _compute_hole_bounding_box(
+        depths_dips_azimuths_table: pd.DataFrame,
+        collar: tuple[float, float, float],
+    ) -> BoundingBox:
+        """
+        Compute 3D bounding box for a deviated hole given collar XYZ and
+        depth / dip / azimuth data.
+
+        Conventions
+        -----------
+        - depths: measured depth along the hole (m), positive downward.
+        - dips: inclination FROM VERTICAL (degrees).
+            90° = vertical down, 0° = horizontal.
+        - azimuths: degrees clockwise from North.
+        - Coordinates: X = Easting, Y = Northing, Z = elevation (up).
+        """
+        df = depths_dips_azimuths_table.dropna(subset=["distance"])
+        box = DownholeCollectionData._compute_bounding_box_np(
+            df["distance"].astype(float).to_numpy(),
+            df["dip"].astype(float).to_numpy(),
+            df["azimuth"].astype(float).to_numpy(),
+            offset=collar,
+        )
+
+        return box
+
+
+class HoleChunksTable(DataTable):
+    table_format: ClassVar[KnownTableFormat] = DOWNHOLE_COLLECTION_LOCATION_HOLES
+    data_columns: ClassVar[list[str]] = ["hole_index", "offset", "count"]
+
+
+class DownholeCategory(Category):
+    @classmethod
+    def _extract_category_table(cls, data: HoleAttributes):
+        return data[["hole_id"]].astype("category")
+
+    @classmethod
+    async def _data_to_schema(cls, data: HoleAttributes, context: IContext) -> Any:
+        category_table = cls._extract_category_table(data)
+        return await super()._data_to_schema(category_table, context=context)
+
+
+class PathTable(DataTable):
+    table_format: ClassVar[KnownTableFormat] = FLOAT_ARRAY_3
+    data_columns: ClassVar[list[str]] = ["distance", "azimuth", "dip"]
+
+
+class DownholePath(DataTableAndAttributes):
+    _table: Annotated[PathTable, SchemaLocation(""), DataLocation("")]
+
+
+class DistancesTable(DataTable):
+    table_format: ClassVar[KnownTableFormat] = FLOAT_ARRAY_3
+    data_columns: ClassVar[list[str]] = ["final", "target", "current"]
+
+    @classmethod
+    def _extract_distances(cls, data: HoleAttributes) -> pd.DataFrame:
+        return data[["final", "target", "current"]].astype(np.float64)
+
+    @classmethod
+    async def _data_to_schema(cls, data: HoleAttributes, context: IContext) -> Any:
+        distances_df = cls._extract_distances(data)
+        return await super()._data_to_schema(distances_df, context)
+
+
+class CollarCoordinates(DataTable):
+    table_format: ClassVar[KnownTableFormat] = FLOAT_ARRAY_3
+    data_columns: ClassVar[list[str]] = _COORDINATE_COLUMNS
+
+    @classmethod
+    def _extract_coordinates(cls, data: HoleAttributes):
+        return data[["x", "y", "z"]].astype(np.float64)
+
+    @classmethod
+    async def _data_to_schema(cls, data: HoleAttributes, context: IContext) -> Any:
+        distances_df = cls._extract_coordinates(data)
+        return await super()._data_to_schema(distances_df, context)
+
+
+class DownholeLocation(SchemaModel):
+    hole_id: Annotated[DownholeCategory, SchemaLocation("hole_id"), DataLocation("properties")]
+    path: Annotated[DownholePath, SchemaLocation("path"), DataLocation("path")]
+    holes: Annotated[HoleChunksTable, SchemaLocation("holes"), DataLocation("holes")]
+    distances: Annotated[DistancesTable, SchemaLocation("distances"), DataLocation("properties")]
+    coordinates: Annotated[CollarCoordinates, SchemaLocation("coordinates"), DataLocation("properties")]
+    attributes: Annotated[Attributes, SchemaLocation("attributes"), DataLocation("attributes")]
+
+
+class _Distances(DataTable):
+    table_format: ClassVar[KnownTableFormat] = FLOAT_ARRAY_1
+    data_columns: ClassVar[list[str]] = ["distance"]
+
+
+class DistanceTableDistances(DataTableAndAttributes):
+    _table: Annotated[_Distances, SchemaLocation("values"), DataLocation("")]
+    unit: Annotated[str | None, SchemaLocation("unit")]
+
+    @classmethod
+    async def _data_to_schema(cls, data: pd.DataFrame, context: IContext) -> Any:
+        result = await super()._data_to_schema(data, context)
+        attr_desc = data.attrs.get("attribute_descriptions", {}).get("distance")
+        if attr_desc is not None:
+            result["unit"] = attr_desc.unit
+        else:
+            result["unit"] = None
+        return result
+
+
+class DistanceTable(SchemaModel):
+    name: Annotated[str, SchemaLocation("name"), DataLocation("name")]
+    collection_type: Annotated[str, SchemaLocation("collection_type"), DataLocation("collection_type")]
+    distance: Annotated[DistanceTableDistances, SchemaLocation("distance"), DataLocation("distance_table")]
+
+
+class DownholeDistanceTable(DistanceTable):
+    holes: Annotated[HoleChunksTable, SchemaLocation("holes"), DataLocation("holes")]
+
+
+class DownholeCollectionTables(SchemaList[DownholeDistanceTable]):
+    pass
+
+
+class DownholeCollection(BaseSpatialObject):
+    """A GeoscienceObject representing a collection of downholes."""
+
+    _data_class = DownholeCollectionData
+    sub_classification = "downhole-collection"
+    creation_schema_version = SchemaVersion(major=1, minor=3, patch=1)
+
+    location: Annotated[DownholeLocation, SchemaLocation("location"), DataLocation("")]
+    collections: Annotated[DownholeCollectionTables, SchemaLocation("collections"), DataLocation("collections")]
+    distance_unit: Annotated[str | None, SchemaLocation("distance_unit")]
+
+    type: ClassVar[Annotated[str, SchemaLocation("type")]] = "downhole"

--- a/packages/evo-objects/src/evo/objects/typed/types.py
+++ b/packages/evo-objects/src/evo/objects/typed/types.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/packages/evo-objects/src/evo/objects/typed/types.py
+++ b/packages/evo-objects/src/evo/objects/typed/types.py
@@ -218,6 +218,20 @@ class BoundingBox:
         )
         return cls.from_extent(origin, extent, rotation)
 
+    @classmethod
+    def combine(cls, bboxes: list[BoundingBox]):
+        if not bboxes:
+            raise ValueError("bboxes list is empty")
+
+        return cls(
+            min_x=min(b.min_x for b in bboxes),
+            max_x=max(b.max_x for b in bboxes),
+            min_y=min(b.min_y for b in bboxes),
+            max_y=max(b.max_y for b in bboxes),
+            min_z=min(b.min_z for b in bboxes),
+            max_z=max(b.max_z for b in bboxes),
+        )
+
 
 @dataclass(frozen=True)
 class Rotation:

--- a/packages/evo-objects/tests/typed/test_downhole_collection.py
+++ b/packages/evo-objects/tests/typed/test_downhole_collection.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/packages/evo-objects/tests/typed/test_downhole_collection.py
+++ b/packages/evo-objects/tests/typed/test_downhole_collection.py
@@ -1,0 +1,407 @@
+#  Copyright © 2025 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import math
+import uuid
+from datetime import date
+from unittest.mock import patch
+
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+from parameterized import parameterized
+
+from evo.common import Environment, StaticContext
+from evo.common.test_tools import BASE_URL, ORG, WORKSPACE_ID, TestWithConnector
+from evo.objects import ObjectReference
+from evo.objects.typed import BoundingBox
+from evo.objects.typed.base import BaseObject
+from evo.objects.typed.downhole_collection import (
+    DistanceCollection,
+    DownholeCollection,
+    DownholeCollectionData,
+)
+from evo.objects.typed.exceptions import ObjectValidationError
+
+from .helpers import MockClient
+
+
+def _make_example_data(
+    name: str = "Test DHC",
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
+    attributes: pd.DataFrame | None = None,
+    collections: list[DistanceCollection] | None = None,
+) -> DownholeCollectionData:
+    """Helper to build a simple two-hole DownholeCollectionData."""
+    # Concatenated path table: hole 0 has 4 rows, hole 1 has 3 rows
+    path = pd.DataFrame(
+        {
+            "distance": [0.0, 10.0, 20.0, 30.0, 0.0, 15.0, 30.0],
+            "azimuth": [0.0, 0.0, 0.0, 0.0, 90.0, 90.0, 90.0],
+            "dip": [90.0, 90.0, 90.0, 90.0, 45.0, 45.0, 45.0],
+        }
+    )
+
+    collection1 = DistanceCollection(
+        name="collection1",
+        collection_type="distance",
+        holes=pd.DataFrame(
+            {
+                "hole_index": [0],
+                "offset": [0],
+                "count": [4],
+            }
+        ),
+        distance_table=pd.DataFrame(
+            {
+                "distance": [0.0, 10.0, 20.0, 30.0],
+                "attr_str": ["a", "b", "a", "c"],
+                "attr_dt": [date(2000, 1, 1), date(2000, 1, 2), date(2000, 1, 3), date(2000, 1, 4)],
+                "attr_num": [1.1, 2.2, 3.3, 4.4],
+            }
+        ),
+    )
+
+    holes = pd.DataFrame(
+        {
+            "hole_index": [0, 1],
+            "offset": [0, 4],
+            "count": [4, 3],
+        }
+    )
+
+    properties = pd.DataFrame(
+        {
+            "hole_id": ["H001", "H002"],
+            "x": [100.0, 200.0],
+            "y": [150.0, 300.0],
+            "z": [0.0, 50.0],
+            "final": [30.0, 30.0],
+            "target": [25.0, 25.0],
+            "current": [30.0, 28.0],
+        }
+    )
+
+    if collections is None:
+        collections = [collection1]
+
+    return DownholeCollectionData(
+        name=name,
+        path=path,
+        holes=holes,
+        properties=properties,
+        attributes=attributes,
+        collections=collections,
+        distance_unit="m",
+        description=description,
+        tags=tags,
+    )
+
+
+class TestDownholeCollection(TestWithConnector):
+    def setUp(self) -> None:
+        TestWithConnector.setUp(self)
+        self.environment = Environment(hub_url=BASE_URL, org_id=ORG.id, workspace_id=WORKSPACE_ID)
+        self.context = StaticContext.from_environment(
+            environment=self.environment,
+            connector=self.connector,
+        )
+
+    @contextlib.contextmanager
+    def _mock_geoscience_objects(self):
+        mock_client = MockClient(self.environment)
+        with (
+            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed._utils.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
+            patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
+            patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),
+        ):
+            yield mock_client
+
+    def _assert_bounding_box_equal(
+        self, bbox: BoundingBox, min_x: float, max_x: float, min_y: float, max_y: float, min_z: float, max_z: float
+    ):
+        self.assertAlmostEqual(bbox.min_x, min_x, places=3)
+        self.assertAlmostEqual(bbox.max_x, max_x, places=3)
+        self.assertAlmostEqual(bbox.min_y, min_y, places=3)
+        self.assertAlmostEqual(bbox.max_y, max_y, places=3)
+        self.assertAlmostEqual(bbox.min_z, min_z, places=3)
+        self.assertAlmostEqual(bbox.max_z, max_z, places=3)
+
+    async def _check_locations(self, expected: DownholeCollectionData, result: DownholeCollection):
+        loc = result.location
+        xyz = ["x", "y", "z"]
+        distances = ["final", "target", "current"]
+
+        npt.assert_array_equal(expected.properties[xyz], await loc.coordinates.to_dataframe())
+        npt.assert_array_equal(expected.properties[distances], await loc.distances.to_dataframe())
+        npt.assert_array_equal(expected.properties[["hole_id"]], await loc.hole_id.to_dataframe())
+        npt.assert_array_equal(expected.holes, await loc.holes.to_dataframe())
+        if expected.attributes:
+            npt.assert_array_equal(expected.attributes, await result.location.hole_id.to_dataframe())
+
+    async def _check_path(self, expected: DownholeCollectionData, result: DownholeCollection):
+        loc = result.location
+        path_columns = ["distance", "azimuth", "dip"]
+        attr_columns = [col for col in expected.path.columns if col not in path_columns]
+
+        npt.assert_array_equal(expected.path[path_columns], await loc.path.to_dataframe())
+        if attr_columns:
+            npt.assert_array_equal(expected.path[attr_columns], await loc.attributes.to_dataframe())
+
+    async def _check_collections(self, expected: DownholeCollectionData, result: DownholeCollection):
+        for expected_collection, result_collection in zip(expected.collections, result.collections, strict=True):
+            expected_distance_unit = expected_collection.distance_table.attrs.get("attribute_descriptions", {}).get(
+                "distance"
+            )
+            self.assertEqual(expected_distance_unit, result_collection.distance.unit)
+
+            expected_table = expected_collection.distance_table
+            result_table = await result_collection.distance.to_dataframe()
+
+            for col in result_table.columns:
+                if pd.api.types.is_datetime64_any_dtype(result_table[col]):
+                    for x, y in zip(expected_table[col], result_table[col]):
+                        self.assertEqual(x.year, y.year)
+                        self.assertEqual(x.month, y.month)
+                        self.assertEqual(x.day, y.day)
+                else:
+                    npt.assert_array_equal(expected_table[col], result_table[col])
+
+    async def _check_dhc(self, expected: DownholeCollectionData, result: DownholeCollection):
+        self.assertIsInstance(result, DownholeCollection)
+        self.assertEqual(expected.name, result.name)
+        self.assertEqual(expected.distance_unit, result.distance_unit)
+
+        await self._check_locations(expected, result)
+        await self._check_path(expected, result)
+        await self._check_collections(expected, result)
+
+    @parameterized.expand([BaseObject, DownholeCollection])
+    async def test_create(self, class_to_call):
+        """Includes collections and attributes"""
+        data = _make_example_data()
+        with self._mock_geoscience_objects():
+            result = await class_to_call.create(context=self.context, data=data)
+        await self._check_dhc(data, result)
+
+    async def test_create_with_empty_collections(self):
+        data = _make_example_data(collections=[])
+        with self._mock_geoscience_objects():
+            result = await DownholeCollection.create(context=self.context, data=data)
+        self.assertIsInstance(result, DownholeCollection)
+
+    @parameterized.expand([BaseObject, DownholeCollection])
+    async def test_replace(self, class_to_call):
+        data = _make_example_data()
+        with self._mock_geoscience_objects():
+            result = await class_to_call.replace(
+                context=self.context,
+                reference=ObjectReference.new(
+                    environment=self.context.get_environment(),
+                    object_id=uuid.uuid4(),
+                ),
+                data=data,
+            )
+        await self._check_dhc(data, result)
+
+    @parameterized.expand([BaseObject, DownholeCollection])
+    async def test_create_or_replace(self, class_to_call):
+        data = _make_example_data()
+        with self._mock_geoscience_objects():
+            result = await class_to_call.create_or_replace(
+                context=self.context,
+                reference=ObjectReference.new(
+                    environment=self.context.get_environment(),
+                    object_id=uuid.uuid4(),
+                ),
+                data=data,
+            )
+        await self._check_dhc(data, result)
+
+    @parameterized.expand([BaseObject, DownholeCollection])
+    async def test_from_reference(self, class_to_call):
+        data = _make_example_data()
+        with self._mock_geoscience_objects():
+            original = await DownholeCollection.create(context=self.context, data=data)
+            result = await class_to_call.from_reference(context=self.context, reference=original.metadata.url)
+        await self._check_dhc(data, result)
+
+    def test_bounding_box(self):
+        """Two vertical holes (dip=90deg) go straight down: bbox should reflect collar + depth. Azimuth doesn't matter"""
+
+        path = pd.DataFrame(
+            {
+                "distance": [0.0, 10.0, 20.0, 30.0, 0.0, 15.0, 30.0],
+                "azimuth": [0.0, 45.0, 20.0, 0.0, 10.0, 90.0, 90.0],
+                "dip": [90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0],
+            }
+        )
+
+        data = _make_example_data()
+        data = dataclasses.replace(data, path=path)
+        bbox = data.compute_bounding_box()
+        self._assert_bounding_box_equal(bbox, 100.0, 200.0, 150.0, 300.0, -30.0, 50.0)
+
+    def test_bounding_box_from_spiral(self):
+        # First hole spirals, second hole zig-zags
+        path = pd.DataFrame(
+            {
+                "distance": [0.0, 10.0, 20.0, 50.0, 0.0, 20.0, 40.0],
+                "azimuth": [0.0, 90.0, 180.0, 270.0, 0.0, 315.0, 90.0],
+                "dip": [60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0],
+            }
+        )
+
+        data = _make_example_data()
+        data = dataclasses.replace(data, path=path)
+        bbox = data.compute_bounding_box()
+
+        # Expected geometry, based on having spiraled and zig-zagged with 30/60/90 and 45/45/90 dips/azimuths
+        xmin = 100.0 - 10
+        xmax = 200.0 - 10 / math.sqrt(2) + 10
+        ymin = 150.0 - 5
+        ymax = 300.0 + 10 / math.sqrt(2)
+        zmin = (-50.0 / 2) * math.sqrt(3)
+        zmax = 50.0
+
+        self._assert_bounding_box_equal(bbox, xmin, xmax, ymin, ymax, zmin, zmax)
+
+    def test_bounding_box_with_nans(self):
+        """Azimuth nans -> 0.0, dip nans -> 90.0"""
+        path = pd.DataFrame(
+            {
+                "distance": [0.0, 10.0, 20.0, 50.0, 0.0, 20.0, 40.0],
+                "azimuth": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+                "dip": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            }
+        )
+
+        data = _make_example_data()
+        data = dataclasses.replace(data, path=path)
+        bbox = data.compute_bounding_box()
+
+        self._assert_bounding_box_equal(bbox, 100.0, 200.0, 150.0, 300.0, -50.0, 50.0)
+
+    def test_compute_bounding_box_np_unsorted_depths_raises(self):
+        with self.assertRaises(ObjectValidationError):
+            DownholeCollectionData._compute_bounding_box_np(
+                depths=np.array([10.0, 5.0, 20.0]),
+                dips=np.array([90.0, 90.0, 90.0]),
+                azimuths=np.array([0.0, 0.0, 0.0]),
+            )
+
+    def test_compute_bounding_box_np_length_mismatch_raises(self):
+        with self.assertRaises(ObjectValidationError):
+            DownholeCollectionData._compute_bounding_box_np(
+                depths=np.array([0.0, 10.0]),
+                dips=np.array([90.0]),
+                azimuths=np.array([0.0, 0.0]),
+            )
+
+    async def test_description_and_tags(self):
+        data = _make_example_data(
+            description="A test downhole collection",
+            tags={"site": "alpha", "status": "active"},
+        )
+        with self._mock_geoscience_objects():
+            result = await DownholeCollection.create(context=self.context, data=data)
+        self.assertEqual(result.description, "A test downhole collection")
+        self.assertEqual(result.tags, {"site": "alpha", "status": "active"})
+
+    def test_attributes_length_raises(self):
+        """attributes length must match holes length."""
+        path = pd.DataFrame({"distance": [0.0, 10.0], "azimuth": [0.0, 0.0], "dip": [90.0, 90.0]})
+        holes = pd.DataFrame({"hole_index": [0, 1], "offset": [0, 1], "count": [1, 1]})
+        properties = pd.DataFrame(
+            {
+                "hole_id": ["H1", "H2"],
+                "x": [0.0, 1.0],
+                "y": [0.0, 1.0],
+                "z": [0.0, 0.0],
+                "final": [10.0, 10.0],
+                "target": [10.0, 10.0],
+                "current": [10.0, 10.0],
+            }
+        )
+        # attributes has 3 rows, but holes has 2 - should assert
+        bad_attributes = pd.DataFrame({"a": [1, 2, 3]})
+        with self.assertRaises(ObjectValidationError):
+            DownholeCollectionData(
+                name="Bad",
+                path=path,
+                holes=holes,
+                properties=properties,
+                attributes=bad_attributes,
+                collections=[],
+                distance_unit=None,
+            )
+
+    async def test_update_dataframe_after_creation(self):
+        """Test updating the path DataFrame after downhole collection creation."""
+        with self._mock_geoscience_objects():
+            data = _make_example_data()
+            obj = await DownholeCollection.create(context=self.context, data=data)
+
+            new_path = pd.DataFrame(
+                {
+                    "distance": [0.0, 10.0, 20.0, 50.0, 0.0, 20.0, 40.0],
+                    "azimuth": [0.0, 90.0, 180.0, 270.0, 0.0, 315.0, 90.0],
+                    "dip": [60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0],
+                }
+            )
+            await obj.location.path.from_dataframe(new_path)
+
+            # Verify the data was updated
+            await obj.update()
+            expected = dataclasses.replace(data, path=new_path)
+            await self._check_dhc(expected, obj)
+
+    async def test_json(self):
+        data = _make_example_data()
+        with self._mock_geoscience_objects() as mock_client:
+            obj = await DownholeCollection.create(context=self.context, data=data)
+            object_json = mock_client.objects[str(obj.metadata.url.object_id)]
+
+            # Verify schema
+            self.assertIn("/objects/downhole-collection/", object_json["schema"])
+
+            # Verify base properties
+            self.assertEqual(object_json["name"], "Test DHC")
+            self.assertIn("uuid", object_json)
+            self.assertIn("bounding_box", object_json)
+            self.assertEqual(object_json["coordinate_reference_system"], "unspecified")
+
+            # Verify type field
+            self.assertEqual(object_json["type"], "downhole")
+
+            # Verify location structure
+            self.assertIn("location", object_json)
+            location = object_json["location"]
+            self.assertIn("path", location)
+            self.assertIn("holes", location)
+            self.assertIn("coordinates", location)
+            self.assertIn("distances", location)
+            self.assertIn("hole_id", location)
+            self.assertIn("collections", object_json)
+            collection = object_json["collections"][0]
+            self.assertIn("name", collection)
+            self.assertIn("collection_type", collection)
+            self.assertEqual(collection["collection_type"], "distance")
+            self.assertIn("holes", collection)
+            self.assertIn("distance", collection)

--- a/packages/evo-objects/tests/typed/test_downhole_collection.py
+++ b/packages/evo-objects/tests/typed/test_downhole_collection.py
@@ -106,6 +106,7 @@ def _make_example_data(
         attributes=attributes,
         collections=collections,
         distance_unit="m",
+        desurvey="trench",
         description=description,
         tags=tags,
     )
@@ -187,6 +188,7 @@ class TestDownholeCollection(TestWithConnector):
         self.assertIsInstance(result, DownholeCollection)
         self.assertEqual(expected.name, result.name)
         self.assertEqual(expected.distance_unit, result.distance_unit)
+        self.assertEqual(expected.desurvey, result.desurvey)
 
         await self._check_locations(expected, result)
         await self._check_path(expected, result)
@@ -350,6 +352,7 @@ class TestDownholeCollection(TestWithConnector):
                 attributes=bad_attributes,
                 collections=[],
                 distance_unit=None,
+                desurvey=None,
             )
 
     async def test_update_dataframe_after_creation(self):
@@ -387,8 +390,10 @@ class TestDownholeCollection(TestWithConnector):
             self.assertIn("bounding_box", object_json)
             self.assertEqual(object_json["coordinate_reference_system"], "unspecified")
 
-            # Verify type field
+            # Verify DHC top level properties
             self.assertEqual(object_json["type"], "downhole")
+            self.assertIn("distance_unit", object_json)
+            self.assertIn("desurvey", object_json)
 
             # Verify location structure
             self.assertIn("location", object_json)

--- a/packages/evo-objects/tests/typed/test_types.py
+++ b/packages/evo-objects/tests/typed/test_types.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at

--- a/packages/evo-objects/tests/typed/test_types.py
+++ b/packages/evo-objects/tests/typed/test_types.py
@@ -139,6 +139,17 @@ class TestTypes(TestCase):
         self.assertAlmostEqual(box.max_y, 0.0)
         self.assertAlmostEqual(box.max_z, 25.0)
 
+    def test_combine_boxes(self):
+        box1 = BoundingBox(min_x=-10.0, max_x=5.0, min_y=-5.0, max_y=10.0, min_z=-15.0, max_z=25.0)
+        box2 = BoundingBox(min_x=1.0, max_x=14.0, min_y=1.0, max_y=22.0, min_z=1.0, max_z=33.0)
+        combined = BoundingBox.combine([box1, box2])
+        self.assertAlmostEqual(combined.min_x, -10.0)
+        self.assertAlmostEqual(combined.max_x, 14.0)
+        self.assertAlmostEqual(combined.min_y, -5.0)
+        self.assertAlmostEqual(combined.max_y, 22.0)
+        self.assertAlmostEqual(combined.min_z, -15.0)
+        self.assertAlmostEqual(combined.max_z, 33.0)
+
 
 class TestEllipsoidRanges(TestCase):
     """Tests for EllipsoidRanges class."""

--- a/packages/evo-widgets/src/evo/widgets/__init__.py
+++ b/packages/evo-widgets/src/evo/widgets/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
@@ -43,7 +43,7 @@ from .formatters import (
     format_report_result,
     format_task_result_list,
     format_task_result_with_target,
-    format_variogram,
+    format_variogram, format_downhole_collection,
 )
 from .urls import (
     get_blocksync_base_url,
@@ -157,6 +157,12 @@ def _register_formatters(ipython: InteractiveShell) -> None:
         "evo.objects.typed.attributes",
         "BlockModelAttributes",
         format_block_model_attributes,
+    )
+
+    html_formatter.for_type_by_name(
+        "evo.objects.typed.downhole_collection",
+        "DownholeCollection",
+        format_downhole_collection,
     )
 
     # Register formatters for compute task results

--- a/packages/evo-widgets/src/evo/widgets/__init__.py
+++ b/packages/evo-widgets/src/evo/widgets/__init__.py
@@ -39,11 +39,12 @@ from .formatters import (
     format_block_model,
     format_block_model_attributes,
     format_block_model_version,
+    format_downhole_collection,
     format_report,
     format_report_result,
     format_task_result_list,
     format_task_result_with_target,
-    format_variogram, format_downhole_collection,
+    format_variogram,
 )
 from .urls import (
     get_blocksync_base_url,

--- a/packages/evo-widgets/src/evo/widgets/formatters.py
+++ b/packages/evo-widgets/src/evo/widgets/formatters.py
@@ -17,7 +17,7 @@ These formatters are registered with IPython when the extension is loaded.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .html import (
     STYLESHEET,

--- a/packages/evo-widgets/src/evo/widgets/formatters.py
+++ b/packages/evo-widgets/src/evo/widgets/formatters.py
@@ -1,4 +1,4 @@
-#  Copyright © 2025 Bentley Systems, Incorporated
+#  Copyright © 2026 Bentley Systems, Incorporated
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
@@ -17,7 +17,7 @@ These formatters are registered with IPython when the extension is loaded.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from .html import (
     STYLESHEET,
@@ -33,12 +33,17 @@ from .urls import (
     get_viewer_url_for_object,
 )
 
+if TYPE_CHECKING:
+    from evo.objects.typed import DownholeCollection
+
+
 __all__ = [
     "format_attributes_collection",
     "format_base_object",
     "format_block_model",
     "format_block_model_attributes",
     "format_block_model_version",
+    "format_downhole_collection",
     "format_report",
     "format_report_result",
     "format_task_result_list",
@@ -149,6 +154,27 @@ def _build_html_from_rows(
     return html
 
 
+def _format_attributes_spec(attributes, rows) -> str:
+    attr_rows = []
+    for attr in attributes:
+        attr_info = attr.as_dict()
+        attr_name = attr_info.get("name", "Unknown")
+        attr_type = attr_info.get("attribute_type", "Unknown")
+        attr_rows.append([attr_name, attr_type])
+
+    return build_nested_table(["Attribute", "Type"], attr_rows)
+
+
+def _format_all_attribute_specs(obj, rows) -> None:
+    # Build datasets section - add as rows to the main table
+    sub_models = getattr(obj, "_sub_models", [])
+    for dataset_name in sub_models:
+        dataset = getattr(obj, dataset_name, None)
+        if dataset and hasattr(dataset, "attributes") and len(dataset.attributes) > 0:
+            # Build attribute rows
+            rows.append((f"{dataset_name}", _format_attributes_spec(dataset.attributes, rows)))
+
+
 def format_base_object(obj: Any) -> str:
     """Format a BaseObject (or subclass) as HTML.
 
@@ -169,21 +195,7 @@ def format_base_object(obj: Any) -> str:
     if crs := doc.get("coordinate_reference_system"):
         rows.append(("CRS:", _format_crs(crs)))
 
-    # Build datasets section - add as rows to the main table
-    sub_models = getattr(obj, "_sub_models", [])
-    for dataset_name in sub_models:
-        dataset = getattr(obj, dataset_name, None)
-        if dataset and hasattr(dataset, "attributes") and len(dataset.attributes) > 0:
-            # Build attribute rows
-            attr_rows = []
-            for attr in dataset.attributes:
-                attr_info = attr.as_dict()
-                attr_name = attr_info.get("name", "Unknown")
-                attr_type = attr_info.get("attribute_type", "Unknown")
-                attr_rows.append([attr_name, attr_type])
-
-            attrs_table = build_nested_table(["Attribute", "Type"], attr_rows)
-            rows.append((f"{dataset_name}:", attrs_table))
+    _format_all_attribute_specs(obj, rows)
 
     return _build_html_from_rows(name, title_links, rows)
 
@@ -299,6 +311,45 @@ def format_variogram(obj: Any) -> str:
         )
 
     return _build_html_from_rows(name, title_links, rows, extra_content)
+
+
+def _format_downhole_collection_collections(obj, rows):
+    for i, collection in enumerate(obj.collections):
+        name = f"Collection {i + 1}"
+        rows.append((f"{name} name:", collection.name))
+        rows.append((f"{name} type:", collection.collection_type))
+        if collection.collection_type == "distance":
+            rows.append((f"{name} distance unit:", collection.distance.unit))
+            if attributes := collection.distance.attributes:
+                rows.append({f"{name} attributes:", _format_attributes_spec(attributes, rows)})
+
+
+
+def format_downhole_collection(obj: DownholeCollection) -> str:
+    """Format a DownholeCollection object as HTML.
+    
+    This formatter renders a downhole collection by extracting metadata and rendering it as a styled HTML table with
+    Portal/Viewer links.
+
+    :param obj: A DownholeCollection object from evo.objects.typed.downhole_collection.
+    :return: HTML string representation.
+    """''
+    doc = obj.as_dict()
+    name, title_links, rows = _get_base_metadata(obj)
+    rows.append(("Bounding box:", _format_bounding_box(doc["bounding_box"])))
+    rows.append(("CRS:", _format_crs(doc["coordinate_reference_system"])))
+
+    # DownholeCollection-specific scalar properties
+    rows.append(("Distance unit:", str(obj.distance_unit)))
+    rows.append(("Desurvey method:", str(obj.desurvey)))
+    rows.append(("Type:", obj.type))
+    rows.append(("Number of holes:", str(obj.location.hole_id.length)))
+
+    _format_all_attribute_specs(obj, rows)
+    _format_all_attribute_specs(obj.location, rows)
+    _format_downhole_collection_collections(obj, rows)
+
+    return _build_html_from_rows(name, title_links, rows)
 
 
 def format_block_model_version(obj: Any) -> str:

--- a/packages/evo-widgets/src/evo/widgets/formatters.py
+++ b/packages/evo-widgets/src/evo/widgets/formatters.py
@@ -324,16 +324,15 @@ def _format_downhole_collection_collections(obj, rows):
                 rows.append({f"{name} attributes:", _format_attributes_spec(attributes, rows)})
 
 
-
 def format_downhole_collection(obj: DownholeCollection) -> str:
     """Format a DownholeCollection object as HTML.
-    
+
     This formatter renders a downhole collection by extracting metadata and rendering it as a styled HTML table with
     Portal/Viewer links.
 
     :param obj: A DownholeCollection object from evo.objects.typed.downhole_collection.
     :return: HTML string representation.
-    """''
+    """
     doc = obj.as_dict()
     name, title_links, rows = _get_base_metadata(obj)
     rows.append(("Bounding box:", _format_bounding_box(doc["bounding_box"])))

--- a/uv.lock
+++ b/uv.lock
@@ -1107,7 +1107,7 @@ test = [
 
 [[package]]
 name = "evo-objects"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "packages/evo-objects" }
 dependencies = [
     { name = "evo-sdk-common", extra = ["jmespath"] },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

This PR introduces a typed "DownholeCollection" object. It is more complicated than the other examples, but it follows the same principals. The implementation and test coverage follows the example of `point_set`.

The most awkward point of design is how the column units are handled. The `DownholeCollectionData` dataclass deals mostly with pandas dataclasses, which don't particularly have a concept of column metadata. So, it's a challenge to figure out how the caller is supposed to attach metadata (such as "units"). The solution I went with is to expect the client to attach auxiliary metadata to pandas `DataFrame.attrs`, which would look like `{'attribute_description': {<column names>:  <AttributeDescription>}, ...}`.

## Checklist

- [x] I have read the contributing guide and the code of conduct
