### PR TITLE
Add KNN and IDW estimation task SDK clients

### DIFF
--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/BlockDiscretisation.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../filters/FilterOperator.html" class="nav-link">
+                                <a rel="prev" href="../knn/KNNRunner.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -14,6 +14,8 @@
 This package groups all geostatistics-topic compute tasks:
 
 - **kriging** — Kriging interpolation
+- **knn** — K-nearest neighbour estimation
+- **idw** — Inverse distance weighting estimation
 - **break_ties** — Spatial tie-breaking
 - **conditioned_simulator** — Conditional turning-band simulation
 - **declustering** — Grid-based declustering weights
@@ -38,6 +40,8 @@ from . import break_ties as _break_ties_module  # noqa: F401
 from . import conditioned_simulator as _conditioned_simulator_module  # noqa: F401
 from . import continuous_distribution as _continuous_distribution_module  # noqa: F401
 from . import declustering as _declustering_module  # noqa: F401
+from . import idw as _idw_module  # noqa: F401
+from . import knn as _knn_module  # noqa: F401
 from . import kriging as _kriging_module  # noqa: F401
 from . import location_wise as _location_wise_module  # noqa: F401
 from . import loss_calculation as _loss_calculation_module  # noqa: F401
@@ -46,6 +50,8 @@ from . import profit_calculation as _profit_calculation_module  # noqa: F401
 from . import simulation_report as _simulation_report_module  # noqa: F401
 from .break_ties import BreakTiesResult
 from .declustering import DeclusteringResult
+from .idw import IDWResult
+from .knn import KNNResult
 from .kriging import (
     BlockDiscretisation,
     Filter,
@@ -58,6 +64,8 @@ __all__ = [
     "BreakTiesResult",
     "DeclusteringResult",
     "Filter",
+    "IDWResult",
+    "KNNResult",
     "KrigingResult",
     "LocationWiseResult",
 ]

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/idw.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/idw.py
@@ -1,0 +1,236 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Inverse distance weighting (IDW) estimation compute task client.
+
+The IDW task estimates values at target locations using a weighted average of
+accepted neighbours, where each weight is inversely proportional to the distance
+raised to ``power``.  A higher power concentrates influence on the closest
+samples; ``power=2`` is the classic IDW setting.
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
+    >>> from evo.compute.tasks.common import Source, Target
+    >>> from evo.compute.tasks.geostatistics.idw import IDWParameters
+    >>>
+    >>> params = IDWParameters(
+    ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+    ...     target=Target.new_attribute(grid, "idw_grade"),
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=20,
+    ...     ),
+    ...     power=2.0,
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+
+from ..common import (
+    AnySourceAttribute,
+    AnyTargetAttribute,
+    Filter,
+    SearchNeighborhood,
+)
+from ..common.results import TaskTarget
+from ..common.runner import TaskRunner
+
+__all__ = [
+    "IDWParameters",
+    "IDWResult",
+    "IDWResultModel",
+    "IDWRunner",
+]
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class IDWParameters(BaseModel):
+    """Parameters for the IDW (inverse distance weighting) estimation task.
+
+    Estimates values at target locations as a distance-weighted average of
+    nearby samples.  The weighting exponent is controlled by ``power``.
+
+    Example:
+        >>> from evo.compute.tasks.common import Filter, FilterCondition, Source, Target
+        >>> from evo.compute.tasks.geostatistics.idw import IDWParameters
+        >>>
+        >>> params = IDWParameters(
+        ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+        ...     target=Target.new_attribute(grid, "idw_grade"),
+        ...     neighborhood=SearchNeighborhood(
+        ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+        ...         max_samples=20,
+        ...     ),
+        ...     power=2.0,
+        ... )
+        >>>
+        >>> # With a target filter to restrict estimation to specific categories on the target:
+        >>> params_filtered = IDWParameters(
+        ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+        ...     target=Target.new_attribute(grid, "idw_grade"),
+        ...     neighborhood=SearchNeighborhood(...),
+        ...     power=2.0,
+        ...     target_filter=Filter(
+        ...         where=FilterCondition(
+        ...             attribute=grid.attributes["domain"],
+        ...             operator="in",
+        ...             values=["LMS1", "LMS2"],
+        ...         ),
+        ...     ),
+        ... )
+    """
+
+    source: AnySourceAttribute
+    """Source object and attribute containing the known values."""
+
+    target: AnyTargetAttribute
+    """Target object and attribute to create or update with IDW estimates."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighbourhood defining which nearby samples to include."""
+
+    power: float = Field(gt=0.0)
+    """Distance-weighting exponent.
+
+    Weights are computed as ``1 / distance ** power`` in the anisotropic space
+    defined by the search ellipsoid.  Common values: ``1.0`` (linear inverse
+    distance), ``2.0`` (classic IDW).  Must be strictly positive.
+    """
+
+    source_filter: Filter | None = Field(None, exclude=True)
+    """Optional filter to restrict estimation to a subset of the source data.
+
+    Excluded from top-level serialisation (``exclude=True``) and injected as
+    ``source["filter"]`` by the custom serialiser.
+    """
+
+    target_filter: Filter | None = Field(None, exclude=True)
+    """Optional filter to restrict estimation to a subset of the target object.
+
+    Excluded from top-level serialisation (``exclude=True``) and injected as
+    ``target["filter"]`` by the custom serialiser.
+    """
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        result = handler(self)
+        if self.source_filter is not None:
+            result["source"]["filter"] = self.source_filter.model_dump()
+        if self.target_filter is not None:
+            result["target"]["filter"] = self.target_filter.model_dump()
+        return result
+
+
+# =============================================================================
+# Result Types
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class IDWResultModel(BaseModel):
+    """Pydantic model for the raw IDW task result payload."""
+
+    message: str
+    """A message describing what happened in the task."""
+
+    target: TaskTarget
+    """Target information from the task result."""
+
+
+class IDWResult:
+    """Rich result object for the IDW estimation task."""
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "IDW Estimation"
+
+    def __init__(self, context: IContext, model: IDWResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        """A message describing what happened in the task."""
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """Reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        """The name of the attribute that was created or updated."""
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object (e.g., ``'pointset'``)."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object."""
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Load the target object and return its data as a DataFrame.
+
+        Args:
+            *columns: Optional column names to select.
+
+        Raises:
+            TypeError: If the target object type does not support DataFrame export.
+        """
+        target_obj = await self.get_target_object()
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        raise TypeError(
+            f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+            "Use get_target_object() and access the data manually."
+        )
+
+    def __str__(self) -> str:
+        return f"✓ {self.TASK_DISPLAY_NAME} Result\n  Target:    {self.target_name}\n  Attribute: {self.attribute_name}"
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class IDWRunner(
+    TaskRunner[IDWParameters, IDWResultModel, IDWResult],
+    topic="geostatistics",
+    task="idw",
+):
+    async def _get_result(self, raw_result: IDWResultModel) -> IDWResult:
+        return IDWResult(self._context, raw_result)

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/knn.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/knn.py
@@ -1,0 +1,224 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""K-nearest neighbour (KNN) estimation compute task client.
+
+The KNN task estimates values at target locations by computing the arithmetic
+mean of the accepted neighbours found within the search ellipsoid.  No
+variogram model is required — it is purely neighbourhood-based.
+
+Example:
+    >>> from evo.compute.tasks import run, SearchNeighborhood, Ellipsoid, EllipsoidRanges
+    >>> from evo.compute.tasks.common import Source, Target
+    >>> from evo.compute.tasks.geostatistics.knn import KNNParameters
+    >>>
+    >>> params = KNNParameters(
+    ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+    ...     target=Target.new_attribute(grid, "knn_grade"),
+    ...     neighborhood=SearchNeighborhood(
+    ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+    ...         max_samples=20,
+    ...     ),
+    ... )
+    >>> result = await run(manager, params)
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+import pandas as pd
+from evo.common import IContext, IFeedback
+from evo.objects import ObjectSchema
+from evo.objects.typed import BaseObject, object_from_reference
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+
+from ..common import (
+    AnySourceAttribute,
+    AnyTargetAttribute,
+    Filter,
+    SearchNeighborhood,
+)
+from ..common.results import TaskTarget
+from ..common.runner import TaskRunner
+
+__all__ = [
+    "KNNParameters",
+    "KNNResult",
+    "KNNResultModel",
+    "KNNRunner",
+]
+
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+
+class KNNParameters(BaseModel):
+    """Parameters for the KNN (K-nearest neighbour) estimation task.
+
+    Estimates values at target locations by computing the arithmetic mean of
+    accepted neighbours found within the search ellipsoid.
+
+    Example:
+        >>> from evo.compute.tasks.common import Filter, FilterCondition, Source, Target
+        >>> from evo.compute.tasks.geostatistics.knn import KNNParameters
+        >>>
+        >>> params = KNNParameters(
+        ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+        ...     target=Target.new_attribute(grid, "knn_grade"),
+        ...     neighborhood=SearchNeighborhood(
+        ...         ellipsoid=Ellipsoid(ranges=EllipsoidRanges(200, 150, 100)),
+        ...         max_samples=20,
+        ...     ),
+        ... )
+        >>>
+        >>> # With a target filter to restrict estimation to specific categories on the target:
+        >>> params_filtered = KNNParameters(
+        ...     source=Source(object=pointset, attribute="locations.attributes[?name=='grade']"),
+        ...     target=Target.new_attribute(grid, "knn_grade"),
+        ...     neighborhood=SearchNeighborhood(...),
+        ...     target_filter=Filter(
+        ...         where=FilterCondition(
+        ...             attribute=grid.attributes["domain"],
+        ...             operator="in",
+        ...             values=["LMS1", "LMS2"],
+        ...         ),
+        ...     ),
+        ... )
+    """
+
+    source: AnySourceAttribute
+    """Source object and attribute containing the known values."""
+
+    target: AnyTargetAttribute
+    """Target object and attribute to create or update with KNN estimates."""
+
+    neighborhood: SearchNeighborhood
+    """Search neighbourhood defining which nearby samples to include."""
+
+    source_filter: Filter | None = Field(None, exclude=True)
+    """Optional filter to restrict estimation to a subset of the source data.
+
+    Excluded from top-level serialisation (``exclude=True``) and injected as
+    ``source["filter"]`` by the custom serialiser.
+    """
+
+    target_filter: Filter | None = Field(None, exclude=True)
+    """Optional filter to restrict estimation to a subset of the target object.
+
+    Excluded from top-level serialisation (``exclude=True``) and injected as
+    ``target["filter"]`` by the custom serialiser.
+    """
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        result = handler(self)
+        if self.source_filter is not None:
+            result["source"]["filter"] = self.source_filter.model_dump()
+        if self.target_filter is not None:
+            result["target"]["filter"] = self.target_filter.model_dump()
+        return result
+
+
+# =============================================================================
+# Result Types
+# =============================================================================
+
+
+@runtime_checkable
+class _ObjToDataframeProtocol(Protocol):
+    async def to_dataframe(self, *keys: str, fb: IFeedback = ...) -> pd.DataFrame: ...
+
+
+class KNNResultModel(BaseModel):
+    """Pydantic model for the raw KNN task result payload."""
+
+    message: str
+    """A message describing what happened in the task."""
+
+    target: TaskTarget
+    """Target information from the task result."""
+
+
+class KNNResult:
+    """Rich result object for the KNN estimation task."""
+
+    TASK_DISPLAY_NAME: ClassVar[str] = "KNN Estimation"
+
+    def __init__(self, context: IContext, model: KNNResultModel) -> None:
+        self._target = model.target
+        self._message = model.message
+        self._context = context
+
+    @property
+    def message(self) -> str:
+        """A message describing what happened in the task."""
+        return self._message
+
+    @property
+    def target_name(self) -> str:
+        """The name of the target object."""
+        return self._target.name
+
+    @property
+    def target_reference(self) -> str:
+        """Reference URL to the target object."""
+        return self._target.reference
+
+    @property
+    def attribute_name(self) -> str:
+        """The name of the attribute that was created or updated."""
+        return self._target.attribute.name
+
+    @property
+    def schema(self) -> ObjectSchema:
+        """The schema type of the target object (e.g., ``'pointset'``)."""
+        return ObjectSchema.from_id(self._target.schema_id)
+
+    async def get_target_object(self) -> BaseObject:
+        """Load and return the target geoscience object."""
+        return await object_from_reference(self._context, self._target.reference)
+
+    async def to_dataframe(self, *columns: str) -> pd.DataFrame:
+        """Load the target object and return its data as a DataFrame.
+
+        Args:
+            *columns: Optional column names to select.
+
+        Raises:
+            TypeError: If the target object type does not support DataFrame export.
+        """
+        target_obj = await self.get_target_object()
+        if isinstance(target_obj, _ObjToDataframeProtocol):
+            return await target_obj.to_dataframe(*columns)
+        raise TypeError(
+            f"Don't know how to get DataFrame from {type(target_obj).__name__}. "
+            "Use get_target_object() and access the data manually."
+        )
+
+    def __str__(self) -> str:
+        return f"✓ {self.TASK_DISPLAY_NAME} Result\n  Target:    {self.target_name}\n  Attribute: {self.attribute_name}"
+
+
+# =============================================================================
+# Task Runner
+# =============================================================================
+
+
+class KNNRunner(
+    TaskRunner[KNNParameters, KNNResultModel, KNNResult],
+    topic="geostatistics",
+    task="knn",
+):
+    async def _get_result(self, raw_result: KNNResultModel) -> KNNResult:
+        return KNNResult(self._context, raw_result)

--- a/packages/evo-compute/tests/geostatistics/test_idw_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_idw_tasks.py
@@ -1,0 +1,302 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for the IDW (inverse distance weighting) estimation task SDK client."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pydantic import ValidationError
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import (
+    Ellipsoid,
+    EllipsoidRanges,
+    Filter,
+    FilterCondition,
+    Source,
+    Target,
+    UpdateAttribute,
+)
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.idw import (
+    IDWParameters,
+    IDWResult,
+    IDWResultModel,
+    IDWRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200, semi_major=150, minor=100)),
+        max_samples=20,
+    )
+
+
+def _params(**kwargs) -> IDWParameters:
+    defaults = dict(
+        source=Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']"),
+        target=Target.new_attribute(GRID_URL, "idw_grade"),
+        neighborhood=_search(),
+        power=2.0,
+    )
+    defaults.update(kwargs)
+    return IDWParameters(**defaults)
+
+
+def _dump(params: IDWParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> IDWResultModel:
+    return IDWResultModel(
+        message="IDW estimation completed.",
+        target=TaskTarget(
+            reference=GRID_URL,
+            name="my-grid",
+            schema_id="/objects/pointset/1.0.0/pointset.schema.json",
+            attribute=TaskAttribute(reference="locations.attributes[0]", name="idw_grade"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestIDWRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(IDWParameters)
+        self.assertIs(runner_cls, IDWRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(IDWRunner.topic, "geostatistics")
+        self.assertEqual(IDWRunner.task, "idw")
+
+    def test_runner_types(self):
+        self.assertIs(IDWRunner.params_type, IDWParameters)
+        self.assertIs(IDWRunner.result_model_type, IDWResultModel)
+        self.assertIs(IDWRunner.result_type, IDWResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization
+# ---------------------------------------------------------------------------
+
+
+class TestIDWParametersSerialization(unittest.TestCase):
+    def test_basic_fields_present(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], POINTSET_URL)
+        self.assertEqual(d["source"]["attribute"], "locations.attributes[?name=='grade']")
+        self.assertEqual(d["target"]["object"], GRID_URL)
+        self.assertIn("neighborhood", d)
+        self.assertEqual(d["power"], 2.0)
+
+    def test_power_is_serialized(self):
+        d = _dump(_params(power=3.0))
+        self.assertEqual(d["power"], 3.0)
+
+    def test_power_must_be_positive(self):
+        with self.assertRaises(ValidationError):
+            _params(power=0.0)
+        with self.assertRaises(ValidationError):
+            _params(power=-1.0)
+
+    def test_different_power_values(self):
+        for power in (0.5, 1.0, 2.0, 3.5):
+            d = _dump(_params(power=power))
+            self.assertAlmostEqual(d["power"], power)
+
+    def test_neighborhood_fields(self):
+        d = _dump(_params())
+        nbr = d["neighborhood"]
+        self.assertIn("ellipsoid", nbr)
+        self.assertEqual(nbr["max_samples"], 20)
+
+    def test_new_attribute_target(self):
+        d = _dump(_params(target=Target.new_attribute(GRID_URL, "result")))
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+        self.assertEqual(d["target"]["attribute"]["name"], "result")
+
+    def test_update_attribute_target(self):
+        from evo.compute.tasks.common.source_target import Target as _Target
+
+        target = _Target(
+            object=GRID_URL,
+            attribute=UpdateAttribute(operation="update", name="existing", reference="attributes[?key=='abc']"),
+        )
+        d = _dump(_params(target=target))
+        self.assertEqual(d["target"]["attribute"]["operation"], "update")
+        self.assertEqual(d["target"]["attribute"]["reference"], "attributes[?key=='abc']")
+
+    def test_no_filter_by_default(self):
+        d = _dump(_params())
+        self.assertNotIn("filter", d.get("target", {}))
+        self.assertNotIn("filter", d.get("source", {}))
+
+    def test_target_filter_injected_into_target(self):
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(
+                    attribute="attributes[?name=='domain']",
+                    operator="in",
+                    values=["LMS1", "LMS2"],
+                ),
+            )
+        )
+        d = _dump(params)
+        f = d["target"]["filter"]
+        self.assertEqual(f["where"]["attribute"], "attributes[?name=='domain']")
+        self.assertEqual(f["where"]["operator"], "in")
+        self.assertEqual(f["where"]["values"], ["LMS1", "LMS2"])
+        self.assertNotIn("filter", d["source"])
+
+    def test_target_filter_with_integer_keys(self):
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(
+                    attribute="attributes[?name=='domain']",
+                    operator="in",
+                    values=[1, 2, 3],
+                ),
+            )
+        )
+        d = _dump(params)
+        self.assertEqual(d["target"]["filter"]["where"]["values"], [1, 2, 3])
+
+    def test_source_filter_injected_into_source(self):
+        params = _params(
+            source_filter=Filter(
+                where=FilterCondition(attribute="grade", operator="greater_than", threshold=0.0),
+            )
+        )
+        d = _dump(params)
+        f = d["source"]["filter"]
+        self.assertEqual(f["where"]["threshold"], 0.0)
+        self.assertNotIn("filter", d["target"])
+
+    def test_filter_excluded_from_top_level(self):
+        """source_filter / target_filter must not appear at the top-level; only inside source/target."""
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(attribute="attributes[?name=='domain']", operator="in", values=["A"]),
+            )
+        )
+        d = _dump(params)
+        self.assertNotIn("target_filter", d)
+        self.assertNotIn("source_filter", d)
+
+    def test_min_samples_in_neighborhood(self):
+        search = SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200, semi_major=150, minor=100)),
+            max_samples=20,
+            min_samples=4,
+        )
+        d = _dump(_params(neighborhood=search))
+        self.assertEqual(d["neighborhood"]["min_samples"], 4)
+
+
+# ---------------------------------------------------------------------------
+# Result handling
+# ---------------------------------------------------------------------------
+
+
+class TestIDWResult(unittest.TestCase):
+    def _make(self) -> IDWResult:
+        return IDWResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertEqual(self._make().message, "IDW estimation completed.")
+
+    def test_target_name(self):
+        self.assertEqual(self._make().target_name, "my-grid")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make().target_reference, GRID_URL)
+
+    def test_attribute_name(self):
+        self.assertEqual(self._make().attribute_name, "idw_grade")
+
+    def test_str(self):
+        s = str(self._make())
+        self.assertIn("IDW Estimation", s)
+        self.assertIn("my-grid", s)
+        self.assertIn("idw_grade", s)
+
+
+# ---------------------------------------------------------------------------
+# Async runner
+# ---------------------------------------------------------------------------
+
+
+class TestIDWRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await IDWRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "idw")
+        self.assertIsInstance(result, IDWResult)
+
+    async def test_runner_passes_power_in_payload(self):
+        ctx = self._make_context()
+        params = _params(power=3.0)
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        captured_payload = {}
+
+        async def capture_submit(**kwargs):
+            captured_payload.update(kwargs)
+            return job
+
+        with patch("evo.compute.tasks.common.runner.JobClient.submit", side_effect=capture_submit):
+            await IDWRunner(ctx, params)
+
+        payload = captured_payload.get("parameters", {})
+        self.assertAlmostEqual(payload.get("power"), 3.0)

--- a/packages/evo-compute/tests/geostatistics/test_knn_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_knn_tasks.py
@@ -1,0 +1,267 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for the KNN (K-nearest neighbour) estimation task SDK client."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from evo.compute.tasks import SearchNeighborhood
+from evo.compute.tasks.common import (
+    Ellipsoid,
+    EllipsoidRanges,
+    Filter,
+    FilterCondition,
+    Source,
+    Target,
+    UpdateAttribute,
+)
+from evo.compute.tasks.common.results import TaskAttribute, TaskTarget
+from evo.compute.tasks.common.runner import TaskRegistry
+from evo.compute.tasks.geostatistics.knn import (
+    KNNParameters,
+    KNNResult,
+    KNNResultModel,
+    KNNRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test.evo.bentley.com"
+_ORG = "00000000-0000-0000-0000-000000000001"
+_WS = "00000000-0000-0000-0000-000000000002"
+
+
+def _obj_url(obj_id: str = "00000000-0000-0000-0000-000000000003") -> str:
+    return f"{_BASE}/geoscience-object/orgs/{_ORG}/workspaces/{_WS}/objects/{obj_id}"
+
+
+POINTSET_URL = _obj_url("00000000-0000-0000-0000-000000000010")
+GRID_URL = _obj_url("00000000-0000-0000-0000-000000000020")
+
+
+def _search() -> SearchNeighborhood:
+    return SearchNeighborhood(
+        ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=200, semi_major=150, minor=100)),
+        max_samples=20,
+    )
+
+
+def _params(**kwargs) -> KNNParameters:
+    defaults = dict(
+        source=Source(object=POINTSET_URL, attribute="locations.attributes[?name=='grade']"),
+        target=Target.new_attribute(GRID_URL, "knn_grade"),
+        neighborhood=_search(),
+    )
+    defaults.update(kwargs)
+    return KNNParameters(**defaults)
+
+
+def _dump(params: KNNParameters) -> dict:
+    return params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _make_result_model() -> KNNResultModel:
+    return KNNResultModel(
+        message="KNN estimation completed.",
+        target=TaskTarget(
+            reference=GRID_URL,
+            name="my-grid",
+            schema_id="/objects/pointset/1.0.0/pointset.schema.json",
+            attribute=TaskAttribute(reference="locations.attributes[0]", name="knn_grade"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestKNNRegistration(unittest.TestCase):
+    def test_registered(self):
+        runner_cls = TaskRegistry().get_runner(KNNParameters)
+        self.assertIs(runner_cls, KNNRunner)
+
+    def test_topic_and_task(self):
+        self.assertEqual(KNNRunner.topic, "geostatistics")
+        self.assertEqual(KNNRunner.task, "knn")
+
+    def test_runner_types(self):
+        self.assertIs(KNNRunner.params_type, KNNParameters)
+        self.assertIs(KNNRunner.result_model_type, KNNResultModel)
+        self.assertIs(KNNRunner.result_type, KNNResult)
+
+
+# ---------------------------------------------------------------------------
+# Parameter serialization
+# ---------------------------------------------------------------------------
+
+
+class TestKNNParametersSerialization(unittest.TestCase):
+    def test_basic_fields_present(self):
+        d = _dump(_params())
+        self.assertEqual(d["source"]["object"], POINTSET_URL)
+        self.assertEqual(d["source"]["attribute"], "locations.attributes[?name=='grade']")
+        self.assertEqual(d["target"]["object"], GRID_URL)
+        self.assertIn("neighborhood", d)
+
+    def test_neighborhood_fields(self):
+        d = _dump(_params())
+        nbr = d["neighborhood"]
+        self.assertIn("ellipsoid", nbr)
+        self.assertEqual(nbr["max_samples"], 20)
+
+    def test_new_attribute_target(self):
+        d = _dump(_params(target=Target.new_attribute(GRID_URL, "result")))
+        self.assertEqual(d["target"]["attribute"]["operation"], "create")
+        self.assertEqual(d["target"]["attribute"]["name"], "result")
+
+    def test_update_attribute_target(self):
+        from evo.compute.tasks.common.source_target import Target as _Target
+
+        target = _Target(
+            object=GRID_URL,
+            attribute=UpdateAttribute(operation="update", name="existing", reference="attributes[?key=='abc']"),
+        )
+        d = _dump(_params(target=target))
+        self.assertEqual(d["target"]["attribute"]["operation"], "update")
+        self.assertEqual(d["target"]["attribute"]["reference"], "attributes[?key=='abc']")
+
+    def test_no_filter_by_default(self):
+        d = _dump(_params())
+        self.assertNotIn("filter", d.get("target", {}))
+        self.assertNotIn("filter", d.get("source", {}))
+
+    def test_target_filter_injected_into_target(self):
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(
+                    attribute="attributes[?name=='domain']",
+                    operator="in",
+                    values=["LMS1", "LMS2"],
+                ),
+            )
+        )
+        d = _dump(params)
+        f = d["target"]["filter"]
+        self.assertEqual(f["where"]["attribute"], "attributes[?name=='domain']")
+        self.assertEqual(f["where"]["operator"], "in")
+        self.assertEqual(f["where"]["values"], ["LMS1", "LMS2"])
+        self.assertNotIn("filter", d["source"])
+
+    def test_target_filter_with_integer_keys(self):
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(
+                    attribute="attributes[?name=='domain']",
+                    operator="in",
+                    values=[1, 2],
+                ),
+            )
+        )
+        d = _dump(params)
+        self.assertEqual(d["target"]["filter"]["where"]["values"], [1, 2])
+
+    def test_source_filter_injected_into_source(self):
+        params = _params(
+            source_filter=Filter(
+                where=FilterCondition(attribute="grade", operator="greater_than", threshold=0.0),
+            )
+        )
+        d = _dump(params)
+        f = d["source"]["filter"]
+        self.assertEqual(f["where"]["threshold"], 0.0)
+        self.assertNotIn("filter", d["target"])
+
+    def test_filter_excluded_from_top_level(self):
+        """source_filter / target_filter must not appear at the top-level; only inside source/target."""
+        params = _params(
+            target_filter=Filter(
+                where=FilterCondition(attribute="attributes[?name=='domain']", operator="in", values=["A"]),
+            )
+        )
+        d = _dump(params)
+        self.assertNotIn("target_filter", d)
+        self.assertNotIn("source_filter", d)
+
+    def test_source_construct_shorthand(self):
+        """Source accepts (object_url, attribute) via Source(...)."""
+        s = Source(object=POINTSET_URL, attribute="grade")
+        params = KNNParameters(
+            source=s,
+            target=Target.new_attribute(GRID_URL, "knn_grade"),
+            neighborhood=_search(),
+        )
+        d = _dump(params)
+        self.assertEqual(d["source"]["attribute"], "grade")
+
+
+# ---------------------------------------------------------------------------
+# Result handling
+# ---------------------------------------------------------------------------
+
+
+class TestKNNResult(unittest.TestCase):
+    def _make(self) -> KNNResult:
+        return KNNResult(MagicMock(), _make_result_model())
+
+    def test_message(self):
+        self.assertEqual(self._make().message, "KNN estimation completed.")
+
+    def test_target_name(self):
+        self.assertEqual(self._make().target_name, "my-grid")
+
+    def test_target_reference(self):
+        self.assertEqual(self._make().target_reference, GRID_URL)
+
+    def test_attribute_name(self):
+        self.assertEqual(self._make().attribute_name, "knn_grade")
+
+    def test_str(self):
+        s = str(self._make())
+        self.assertIn("KNN Estimation", s)
+        self.assertIn("my-grid", s)
+        self.assertIn("knn_grade", s)
+
+
+# ---------------------------------------------------------------------------
+# Async runner
+# ---------------------------------------------------------------------------
+
+
+class TestKNNRunnerAsync(unittest.IsolatedAsyncioTestCase):
+    def _make_context(self):
+        ctx = MagicMock()
+        ctx.get_connector.return_value = MagicMock()
+        ctx.get_org_id.return_value = "test-org"
+        return ctx
+
+    async def test_runner_submits_correctly(self):
+        ctx = self._make_context()
+        params = _params()
+        job = AsyncMock()
+        job.wait_for_results.return_value = _make_result_model()
+
+        with patch(
+            "evo.compute.tasks.common.runner.JobClient.submit",
+            new_callable=AsyncMock,
+            return_value=job,
+        ) as mock_submit:
+            result = await KNNRunner(ctx, params)
+
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        self.assertEqual(kwargs["topic"], "geostatistics")
+        self.assertEqual(kwargs["task"], "knn")
+        self.assertIsInstance(result, KNNResult)


### PR DESCRIPTION
## Description

Adds typed SDK clients for the two distance-based estimation compute tasks in the `geostatistics` topic.

### KNN (`packages/evo-compute/src/evo/compute/tasks/geostatistics/knn.py`)

- `KNNParameters` — source, target, neighbourhood, and optional `source_filter` / `target_filter` (`Filter` objects, serialised into the nested `source` / `target` dicts via a custom `model_serializer`).
- `KNNResultModel` / `KNNResult` — rich result object with `message`, `target_name`, `target_reference`, `attribute_name`, `schema`, `get_target_object()`, and `to_dataframe()`.
- `KNNRunner` — `TaskRunner` subclass registered as `geostatistics:knn`.

### IDW (`packages/evo-compute/src/evo/compute/tasks/geostatistics/idw.py`)

- `IDWParameters` — same shape as KNN plus a `power: float` field (distance-weighting exponent, must be `> 0`).
- `IDWResultModel` / `IDWResult` — same rich result API as KNN.
- `IDWRunner` — `TaskRunner` subclass registered as `geostatistics:idw`.

### Other changes

- `geostatistics/__init__.py` — imports both modules (to register runners) and re-exports `IDWResult` / `KNNResult`.
- `tests/geostatistics/test_knn_tasks.py` — 19 tests covering registration, parameter serialisation (including filter injection into source/target), result properties, and async runner.
- `tests/geostatistics/test_idw_tasks.py` — 24 tests covering the same areas plus `power` validation.

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Code is linted (ruff check passes with no errors)
- [x] All tests pass (43/43)
- [x] No breaking changes introduced