### PR TITLE
chore: bump evo-compute to v0.0.4

### DIFF
--- a/packages/evo-compute/pyproject.toml
+++ b/packages/evo-compute/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-compute"
-version = "0.0.3"
+version = "0.0.4"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/uv.lock
+++ b/uv.lock
@@ -980,7 +980,7 @@ test = [
 
 [[package]]
 name = "evo-compute"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "packages/evo-compute" }
 dependencies = [
     { name = "evo-blockmodels", extra = ["utils"] },


### PR DESCRIPTION
## Description

Bumps `evo-compute` version from `0.0.3` → `0.0.4` in preparation for a PyPI release.

### What's included in this release

Since `evo-compute@0.0.3`, the following changes have landed on `main`:

- **Normal-score task** — Add normal-score compute task SDK client ([#268](https://github.com/SeequentEvo/evo-python-sdk/pull/268))
- **Simulation-report task** — Add simulation-report compute task SDK client ([#264](https://github.com/SeequentEvo/evo-python-sdk/pull/264))
- **Loss-calculation task** — Add loss-calculation task SDK client ([#262](https://github.com/SeequentEvo/evo-python-sdk/pull/262))
- **Profit-calculation task** — Add profit-calculation task SDK client ([#261](https://github.com/SeequentEvo/evo-python-sdk/pull/261))
- **Declustering task** — Add declustering compute task SDK client ([#289](https://github.com/SeequentEvo/evo-python-sdk/pull/289))
- **Continuous-distribution task** — Add continuous-distribution task SDK client ([#263](https://github.com/SeequentEvo/evo-python-sdk/pull/263))
- **Conditioned simulator task** — Add conditioned simulator (consim) task SDK client ([#267](https://github.com/SeequentEvo/evo-python-sdk/pull/267))
- **Kriging task update** — Update kriging task SDK client to match current task implementation ([#300](https://github.com/SeequentEvo/evo-python-sdk/pull/300))
- **Conditional turning-bands simulation task** — Add conditional turning-bands simulation task SDK client ([#308](https://github.com/SeequentEvo/evo-python-sdk/pull/308))
- **KNN and IDW estimation tasks** — Add KNN and IDW estimation task SDK clients ([#307](https://github.com/SeequentEvo/evo-python-sdk/pull/307))

## Checklist

- [x] I have read the contributing guide and the code of conduct
- [x] Version bumped in `packages/evo-compute/pyproject.toml`
- [x] No breaking changes