### PR TITLE
Improve error when a non-existent attribute is used as a source

### DIFF
--- a/packages/evo-compute/src/evo/compute/tasks/common/source_target.py
+++ b/packages/evo-compute/src/evo/compute/tasks/common/source_target.py
@@ -194,10 +194,37 @@ class Target(BaseModel):
 # =============================================================================
 
 
+def _available_attribute_names(attr: PendingAttribute | BlockModelPendingAttribute) -> list[str]:
+    """Best-effort list of the sibling attribute names on the parent object.
+
+    Used only to enrich error messages, so it must never raise.
+
+    Args:
+        attr: A pending attribute whose parent object's existing attributes we want to list.
+
+    Returns:
+        The names of the existing attributes on the parent object, or an empty list if
+        they cannot be determined.
+    """
+    try:
+        # PendingAttribute exposes the parent Attributes collection; BlockModelPendingAttribute
+        # exposes the parent object, whose ``.attributes`` is the collection.
+        collection = getattr(attr, "_parent", None)
+        if collection is None:
+            collection = getattr(getattr(attr, "_obj", None), "attributes", None)
+        if collection is None:
+            return []
+        return [name for a in collection if isinstance(name := getattr(a, "name", None), str)]
+    except Exception:
+        return []
+
+
 def _source_from_attribute(attr: Source | Attribute | BlockModelAttribute) -> Source:
     """Convert a typed ``Attribute`` or ``BlockModelAttribute`` to a :class:`Source`.
 
     Only existing attributes can be used as a source, since source data must already exist.
+    A pending (non-existent) attribute — commonly the result of a typo in the attribute
+    name — is rejected with a clear, actionable error instead of a generic type error.
 
     Args:
         attr: An existing ``Attribute`` from a DownloadedObject, or a ``BlockModelAttribute``.
@@ -206,9 +233,17 @@ def _source_from_attribute(attr: Source | Attribute | BlockModelAttribute) -> So
         A :class:`Source` referencing the parent object and attribute expression.
 
     Raises:
-        TypeError: If *attr* is not a supported attribute type, or if it has
-            no ``_obj`` reference to its parent object.
+        ValueError: If *attr* is a non-existent (pending) attribute, or an existing attribute
+            without an ``_obj`` reference to its parent object.
     """
+    if isinstance(attr, (PendingAttribute, BlockModelPendingAttribute)):
+        available = _available_attribute_names(attr)
+        hint = f" Available attributes: {available}." if available else ""
+        raise ValueError(
+            f"Source attribute {attr.name!r} does not exist on the source object. "
+            f"A source must reference an existing attribute containing the input values.{hint}"
+        )
+
     if not isinstance(attr, (Attribute, BlockModelAttribute)):
         return attr  # Allow passthrough of already-constructed Source or other types
 

--- a/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
@@ -11,6 +11,7 @@
 
 """Tests for kriging task parameter handling."""
 
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -149,8 +150,22 @@ class TestAnySourceAttribute(TestCase):
 
     def test_source_from_attribute_raises_for_pending(self):
         pending = _create_pending_attribute("new_attr")
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as ctx:
             self.ta.validate_python(pending)
+        message = str(ctx.exception)
+        self.assertIn("new_attr", message)
+        self.assertIn("does not exist", message)
+
+    def test_source_from_pending_lists_available_attributes(self):
+        parent = MagicMock()
+        parent.__iter__.return_value = iter([SimpleNamespace(name="grade"), SimpleNamespace(name="au_ppm")])
+        pending = PendingAttribute(parent, "grde")
+        with self.assertRaises(ValidationError) as ctx:
+            self.ta.validate_python(pending)
+        message = str(ctx.exception)
+        self.assertIn("grde", message)
+        self.assertIn("grade", message)
+        self.assertIn("au_ppm", message)
 
     def test_source_from_attribute_raises_for_block_model_attribute(self):
         bm_attr = BlockModelAttribute(name="grade", attribute_type="Float64")


### PR DESCRIPTION
## Description

If you look up an attribute by name that doesn't exist on an object, `attributes["missing_name"]` returns a `PendingAttribute` — which is the right behaviour for targets (create a new attribute). But passing that to a compute task as a *source* produces a generic pydantic type error that's difficult to interpret:

```
ValidationError: 1 validation error for KrigingParameters
source
  Input should be a valid dictionary or instance of Source [type=model_type, input_value=PendingAttribute(name='Ag...m Values', exists=False)]
```

This is usually just a typo in the attribute name, but nothing in the error tells you that.

This change catches non-existent attributes early in `_source_from_attribute` and raises a clear error that names the missing attribute and lists what's actually on the object:

```
ValueError: Source attribute 'Ag_ppm Values' does not exist on the source object.
A source must reference an existing attribute containing the input values.
Available attributes: ['Ag_ppm', 'Au_ppm', 'Cu_pct'].
```

Also adds a test that asserts the message and the available-attributes hint.

## Checklist

- [x] I have read the contributing guide and the code of conduct