### PR TITLE
Couple of changes to support Python 3.14

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.24"
+version = "0.5.25"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/oauth/oauth_redirect_handler.py
+++ b/packages/evo-sdk-common/src/evo/oauth/oauth_redirect_handler.py
@@ -118,7 +118,7 @@ class OAuthRedirectHandler:
         """
         self.__oauth_connector = oauth_connector
         self.__runner: web.AppRunner | None = None  # The HTTP server runner.
-        self.__authorisation: asyncio.Future[AccessToken] = asyncio.get_event_loop().create_future()
+        self.__authorisation: asyncio.Future[AccessToken] | None = None
         self.__redirect_url = redirect_url
         self.__state: str | None = None
         self.__verifier: str | None = None
@@ -131,6 +131,8 @@ class OAuthRedirectHandler:
 
         The context is pending if the token has not been fetched and no errors have occurred.
         """
+        if self.__authorisation is None:
+            return True
         return not self.__authorisation.done()
 
     def __check_server_started(self) -> None:
@@ -145,6 +147,8 @@ class OAuthRedirectHandler:
         """Start the OAuth HTTP server."""
         if self.__runner is not None:
             raise OAuthError("OAuth redirect server cannot be reused.")
+
+        self.__authorisation = asyncio.get_running_loop().create_future()
 
         logger.debug("Opening connector...")
         await self.__oauth_connector.__aenter__()
@@ -203,8 +207,7 @@ class OAuthRedirectHandler:
         except Exception as exc:  # noqa: E722
             logger.error("Unable to fetch access token.", exc_info=True)
             self.__authorisation.set_exception(OAuthError(str(exc)).with_traceback(exc.__traceback__))
-        finally:  # Always return the response to the web client.
-            return response
+        return response
 
     async def get_result(self, timeout_seconds: int | float = 60) -> AccessToken:
         """Get the result of the authorisation process.

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.5.24"
+version = "0.5.25"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

- Removes `return` from a `finally` block to eliminate a Python 3.14 `SyntaxWarning` ([PEP 765](https://docs.python.org/3.14/whatsnew/3.14.html#pep-765-control-flow-in-finally-blocks))
- Moves `asyncio.Future` creation from `__init__` to `__aenter__` to avoid the `RuntimeError` now raised by `asyncio.get_event_loop()` when no loop is running. [Reference](https://docs.python.org/3.14/whatsnew/3.14.html#id10)


## Checklist

- [x] I have read the contributing guide and the code of conduct
