### PR TITLE
Add evo.common.crs with EpsgCode and parse_crs

### DIFF
--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-objects"
 description = "Python SDK for using the Seequent Evo Geoscience Object API"
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 dependencies = [
-    "evo-sdk-common[jmespath]>=0.5.8",
+    "evo-sdk-common[jmespath]>=0.5.26",
     "pydantic>=2,<3",
 ]
 

--- a/packages/evo-objects/src/evo/objects/typed/spatial.py
+++ b/packages/evo-objects/src/evo/objects/typed/spatial.py
@@ -48,6 +48,7 @@ class BaseSpatialObject(BaseObject):
     """Base class for all Geoscience Objects with spatial data."""
 
     _bbox_type_adapter: ClassVar[TypeAdapter[BoundingBox]] = TypeAdapter(BoundingBox)
+    _crs_type_adapter: ClassVar[TypeAdapter[CoordinateReferenceSystem]] = TypeAdapter(CoordinateReferenceSystem)
     _bounding_box: Annotated[BoundingBox, SchemaLocation("bounding_box")]
     coordinate_reference_system: Annotated[CoordinateReferenceSystem, SchemaLocation("coordinate_reference_system")]
 
@@ -56,14 +57,7 @@ class BaseSpatialObject(BaseObject):
         """Create a object dictionary suitable for creating a new Geoscience Object."""
         object_dict = await super()._data_to_schema(data, context)
         object_dict["bounding_box"] = cls._bbox_type_adapter.dump_python(data.compute_bounding_box())
-        # Always set coordinate_reference_system, defaulting to "unspecified" if None
-        crs = data.coordinate_reference_system
-        if crs is None:
-            object_dict["coordinate_reference_system"] = "unspecified"
-        elif isinstance(crs, int):
-            object_dict["coordinate_reference_system"] = {"epsg_code": crs}
-        else:
-            object_dict["coordinate_reference_system"] = crs
+        object_dict["coordinate_reference_system"] = cls._crs_type_adapter.dump_python(data.coordinate_reference_system)
         return object_dict
 
     # The bounding box is defined as regular a property so that subclasses can override it if needed

--- a/packages/evo-objects/src/evo/objects/typed/types.py
+++ b/packages/evo-objects/src/evo/objects/typed/types.py
@@ -17,9 +17,9 @@ from typing import Annotated, Any, overload
 import numpy as np
 import numpy.typing as npt
 import pydantic
-from pydantic_core import core_schema
 
 # Import basic geometry types from evo.common and re-export
+from evo.common.crs import EpsgCode, parse_crs
 from evo.common.typed import Point3, Size3d, Size3i
 
 __all__ = [
@@ -35,36 +35,6 @@ __all__ = [
 ]
 
 
-class EpsgCode(int):
-    """An integer representing an EPSG code."""
-
-    def __new__(cls, value: int | str) -> EpsgCode:
-        if isinstance(value, str):
-            try:
-                value = int(value)
-            except ValueError as ve:
-                raise ValueError(f"Cannot convert '{value}' to an integer EPSG code") from ve
-
-        if not (1024 <= value <= 32767):
-            raise ValueError(f"EPSG code must be between 1024 and 32767, got {value}")
-
-        return int.__new__(cls, value)
-
-    def __repr__(self) -> str:
-        return f"EpsgCode({int(self)})"
-
-    def __str__(self):
-        return f"EPSG:{int(self)}"
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
-        return core_schema.no_info_after_validator_function(
-            cls,
-            core_schema.int_schema(),
-            serialization=core_schema.plain_serializer_function_ser_schema(int),
-        )
-
-
 def _dump_crs(value: EpsgCode | str | None) -> Any:
     if value is None:
         return "unspecified"
@@ -78,16 +48,15 @@ def _dump_crs(value: EpsgCode | str | None) -> Any:
 
 def _load_crs(value: Any) -> EpsgCode | str | None:
     if value == "unspecified":
-        return None
-    elif isinstance(value, dict):
-        if "epsg_code" in value:
-            return EpsgCode(value["epsg_code"])
-        elif "ogc_wkt" in value:
-            return value["ogc_wkt"]
-        else:
-            raise ValueError("Invalid CRS dictionary format")
-    else:
+        return parse_crs(value)
+    if not isinstance(value, dict):
         raise ValueError("Invalid CRS format")
+
+    if set(value) == {"epsg_code"}:
+        return parse_crs(value["epsg_code"])
+    if set(value) == {"ogc_wkt"} and isinstance(value["ogc_wkt"], str):
+        return value["ogc_wkt"]
+    raise ValueError("Invalid CRS dictionary format")
 
 
 CoordinateReferenceSystem = Annotated[

--- a/packages/evo-objects/tests/typed/test_types.py
+++ b/packages/evo-objects/tests/typed/test_types.py
@@ -16,8 +16,9 @@ from unittest import TestCase
 import numpy as np
 import numpy.testing as npt
 from parameterized import parameterized
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
+from evo.common import EpsgCode as CommonEpsgCode
 from evo.objects.typed import (
     BoundingBox,
     CoordinateReferenceSystem,
@@ -29,6 +30,8 @@ from evo.objects.typed import (
     Size3d,
     Size3i,
 )
+from evo.objects.typed.spatial import BaseSpatialObject
+from evo.objects.typed.types import EpsgCode as TypesEpsgCode
 
 
 class TestTypes(TestCase):
@@ -75,6 +78,28 @@ class TestTypes(TestCase):
         self.assertEqual(type_adapter.dump_python(crs1), {"epsg_code": 4326})
         self.assertEqual(type_adapter.dump_python(crs2), {"ogc_wkt": "WKT_STRING"})
         self.assertEqual(type_adapter.dump_python(crs3), "unspecified")
+
+    def test_epsg_code_reexport_is_the_same_class(self):
+        self.assertIs(CommonEpsgCode, EpsgCode)
+        self.assertIs(CommonEpsgCode, TypesEpsgCode)
+
+    def test_spatial_crs_serializer_uses_schema_wire_shape(self):
+        adapter = BaseSpatialObject._crs_type_adapter
+        self.assertEqual(adapter.dump_python(EpsgCode(2193)), {"epsg_code": 2193})
+        self.assertEqual(adapter.dump_python("WKT_STRING"), {"ogc_wkt": "WKT_STRING"})
+        self.assertEqual(adapter.dump_python(None), "unspecified")
+
+    @parameterized.expand(
+        [
+            ("both", {"epsg_code": 4326, "ogc_wkt": "WKT_STRING"}),
+            ("extra", {"epsg_code": 4326, "extra": True}),
+            ("wrong_wkt_type", {"ogc_wkt": 42}),
+            ("unexpected", {"unexpected": 4326}),
+        ]
+    )
+    def test_invalid_crs_wire_shapes_raise(self, _name, value):
+        with self.assertRaises(ValidationError):
+            TypeAdapter(CoordinateReferenceSystem).validate_python(value)
 
     def test_bounding_box_from_extent_no_rotation(self):
         """Test BoundingBox.from_extent without rotation."""

--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.25"
+version = "0.5.26"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/__init__.py
+++ b/packages/evo-sdk-common/src/evo/common/__init__.py
@@ -11,6 +11,7 @@
 
 from .connector import APIConnector, NoAuth
 from .context import StaticContext
+from .crs import EpsgCode, parse_crs
 from .data import (
     DependencyStatus,
     EmptyResponse,
@@ -36,6 +37,7 @@ __all__ = [
     "DependencyStatus",
     "EmptyResponse",
     "Environment",
+    "EpsgCode",
     "EvoContext",
     "HTTPHeaderDict",
     "HTTPResponse",
@@ -56,4 +58,5 @@ __all__ = [
     "Size3d",
     "Size3i",
     "StaticContext",
+    "parse_crs",
 ]

--- a/packages/evo-sdk-common/src/evo/common/crs.py
+++ b/packages/evo-sdk-common/src/evo/common/crs.py
@@ -1,0 +1,113 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Coordinate reference system (CRS) types and parsing helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Final
+
+from pydantic_core import core_schema
+
+__all__ = [
+    "EpsgCode",
+    "parse_crs",
+]
+
+MIN_EPSG_CODE: Final[int] = 1024
+"""The lowest valid EPSG code."""
+
+MAX_EPSG_CODE: Final[int] = 32767
+"""The highest valid EPSG code."""
+
+UNSPECIFIED_EPSG_CODE: Final[int] = 404000
+"""The EPSG code used to signal that no CRS is specified."""
+
+_UNSPECIFIED_STRINGS: Final[frozenset[str]] = frozenset({"", "unspecified"})
+
+# "EPSG:1234", "EPSG::1234", "epsg 1234"
+_EPSG_PREFIXED = re.compile(r"^epsg[\s:]+(-?\d+)$", re.IGNORECASE)
+
+# "urn:ogc:def:crs:EPSG::1234", "urn:x-ogc:def:crs:EPSG:6.6:1234"
+_EPSG_URN = re.compile(r"^urn:[\w\-]+:def:crs:epsg:[^:]*:(-?\d+)$", re.IGNORECASE)
+
+# A bare numeric string, e.g. "1234"
+_EPSG_BARE = re.compile(r"^(-?\d+)$")
+
+
+class EpsgCode(int):
+    """An integer representing an EPSG code."""
+
+    def __new__(cls, value: int | str) -> EpsgCode:
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except ValueError as ve:
+                raise ValueError(f"Cannot convert '{value}' to an integer EPSG code") from ve
+
+        if not (MIN_EPSG_CODE <= value <= MAX_EPSG_CODE):
+            raise ValueError(f"EPSG code must be between {MIN_EPSG_CODE} and {MAX_EPSG_CODE}, got {value}")
+
+        return int.__new__(cls, value)
+
+    def __repr__(self) -> str:
+        return f"EpsgCode({int(self)})"
+
+    def __str__(self) -> str:
+        return f"EPSG:{int(self)}"
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.int_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(int),
+        )
+
+
+def parse_crs(value: int | str | None) -> EpsgCode | str | None:
+    """Normalise a coordinate reference system reference.
+
+    Accepts an ``int``, ``"EPSG:1234"``, ``"urn:ogc:def:crs:EPSG::1234"``, a bare numeric string, or
+    an OGC WKT string. ``None``, ``"unspecified"``, ``""`` and EPSG ``404000`` all map to ``None``.
+    Any other ``str`` is passed through unchanged as OGC WKT.
+
+    :param value: The CRS reference to normalise.
+
+    :return: An :class:`EpsgCode`, an OGC WKT ``str``, or ``None`` when no CRS is specified.
+
+    :raises TypeError: If the value is not an ``int``, ``str`` or ``None``.
+    :raises ValueError: If an EPSG-shaped value is outside the valid range
+        [``MIN_EPSG_CODE``, ``MAX_EPSG_CODE``].
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        raise TypeError(f"CRS value must be an int, str or None, got {type(value).__name__}")
+
+    if isinstance(value, int):
+        return None if value == UNSPECIFIED_EPSG_CODE else EpsgCode(value)
+
+    if not isinstance(value, str):
+        raise TypeError(f"CRS value must be an int, str or None, got {type(value).__name__}")
+
+    stripped = value.strip()
+    if stripped.lower() in _UNSPECIFIED_STRINGS:
+        return None
+
+    for pattern in (_EPSG_PREFIXED, _EPSG_URN, _EPSG_BARE):
+        if (match := pattern.match(stripped)) is not None:
+            return parse_crs(int(match.group(1)))
+
+    # Anything else is assumed to be an OGC WKT string, and is passed through unchanged.
+    return value

--- a/packages/evo-sdk-common/tests/test_crs.py
+++ b/packages/evo-sdk-common/tests/test_crs.py
@@ -1,0 +1,145 @@
+#  Copyright © 2026 Bentley Systems, Incorporated
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+
+from parameterized import parameterized
+
+from evo.common import EpsgCode, parse_crs
+from evo.common.crs import MAX_EPSG_CODE, MIN_EPSG_CODE, UNSPECIFIED_EPSG_CODE
+
+WKT = (
+    'PROJCS["NZGD2000 / New Zealand Transverse Mercator 2000",'
+    'GEOGCS["NZGD2000",DATUM["New_Zealand_Geodetic_Datum_2000"]]]'
+)
+
+
+class TestEpsgCode(unittest.TestCase):
+    def test_from_int(self) -> None:
+        code = EpsgCode(2193)
+        self.assertIsInstance(code, int)
+        self.assertEqual(2193, code)
+
+    def test_from_str(self) -> None:
+        self.assertEqual(2193, EpsgCode("2193"))
+
+    def test_repr_and_str(self) -> None:
+        code = EpsgCode(2193)
+        self.assertEqual("EpsgCode(2193)", repr(code))
+        self.assertEqual("EPSG:2193", str(code))
+
+    @parameterized.expand(
+        [
+            ("below_min", MIN_EPSG_CODE - 1),
+            ("above_max", MAX_EPSG_CODE + 1),
+            ("zero", 0),
+            ("negative", -1),
+            ("unspecified_sentinel", UNSPECIFIED_EPSG_CODE),
+        ]
+    )
+    def test_out_of_range_raises(self, _name: str, value: int) -> None:
+        with self.assertRaises(ValueError):
+            EpsgCode(value)
+
+    def test_non_numeric_str_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            EpsgCode("not-a-number")
+
+
+class TestParseCrs(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("int", 2193),
+            ("bare_numeric_str", "2193"),
+            ("epsg_prefixed", "EPSG:2193"),
+            ("epsg_prefixed_lowercase", "epsg:2193"),
+            ("epsg_double_colon", "EPSG::2193"),
+            ("epsg_spaced", "EPSG: 2193"),
+            ("epsg_space_separated", "EPSG 2193"),
+            ("urn", "urn:ogc:def:crs:EPSG::2193"),
+            ("urn_versioned", "urn:ogc:def:crs:EPSG:6.6:2193"),
+            ("urn_x_ogc", "urn:x-ogc:def:crs:EPSG::2193"),
+            ("surrounding_whitespace", "  EPSG:2193  "),
+        ]
+    )
+    def test_epsg_forms(self, _name: str, value: int | str) -> None:
+        result = parse_crs(value)
+        self.assertIsInstance(result, EpsgCode)
+        self.assertEqual(2193, result)
+
+    @parameterized.expand(
+        [
+            ("none", None),
+            ("empty_str", ""),
+            ("whitespace_only", "   "),
+            ("unspecified", "unspecified"),
+            ("unspecified_mixed_case", "Unspecified"),
+            ("sentinel_int", UNSPECIFIED_EPSG_CODE),
+            ("sentinel_str", "404000"),
+            ("sentinel_epsg", "EPSG:404000"),
+            ("sentinel_urn", "urn:ogc:def:crs:EPSG::404000"),
+        ]
+    )
+    def test_unspecified_maps_to_none(self, _name: str, value: int | str | None) -> None:
+        self.assertIsNone(parse_crs(value))
+
+    def test_wkt_passthrough_unchanged(self) -> None:
+        result = parse_crs(WKT)
+        self.assertIsInstance(result, str)
+        self.assertNotIsInstance(result, EpsgCode)
+        self.assertEqual(WKT, result)
+
+    def test_wkt_with_whitespace_is_not_stripped(self) -> None:
+        value = f"  {WKT}  "
+        self.assertEqual(value, parse_crs(value))
+
+    @parameterized.expand([("unknown", "unknown"), ("none", "none")])
+    def test_unrecognised_strings_are_preserved(self, _name: str, value: str) -> None:
+        self.assertEqual(value, parse_crs(value))
+
+    @parameterized.expand(
+        [
+            ("below_min_int", MIN_EPSG_CODE - 1),
+            ("above_max_int", MAX_EPSG_CODE + 1),
+            ("below_min_str", "EPSG:1023"),
+            ("above_max_str", "32768"),
+            ("above_max_urn", "urn:ogc:def:crs:EPSG::99999"),
+            ("negative_bare_str", "-1"),
+            ("negative_prefixed_str", "EPSG:-1"),
+            ("negative_urn", "urn:ogc:def:crs:EPSG::-1"),
+        ]
+    )
+    def test_out_of_range_raises(self, _name: str, value: int | str) -> None:
+        with self.assertRaises(ValueError):
+            parse_crs(value)
+
+    @parameterized.expand(
+        [
+            ("float", 2193.0),
+            ("bool_true", True),
+            ("bool_false", False),
+            ("list", [2193]),
+            ("dict", {"epsg_code": 2193}),
+            ("bytes", b"EPSG:2193"),
+        ]
+    )
+    def test_bad_type_raises_type_error(self, _name: str, value: object) -> None:
+        with self.assertRaises(TypeError):
+            parse_crs(value)  # type: ignore[arg-type]
+
+    def test_idempotent(self) -> None:
+        for value in (2193, "EPSG:2193", WKT, None, "unspecified"):
+            once = parse_crs(value)  # type: ignore[arg-type]
+            self.assertEqual(once, parse_crs(once))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1107,7 +1107,7 @@ test = [
 
 [[package]]
 name = "evo-objects"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/evo-objects" }
 dependencies = [
     { name = "evo-sdk-common", extra = ["jmespath"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ test = [
 
 [[package]]
 name = "evo-sdk-common"
-version = "0.5.25"
+version = "0.5.26"
 source = { editable = "packages/evo-sdk-common" }
 dependencies = [
     { name = "pure-interface" },


### PR DESCRIPTION
## Description

Moves EpsgCode from evo.objects.typed.types into a new evo.common.crs module in evo-sdk-common, and adds parse_crs() to normalise CRS references (int, 'EPSG:1234', 'urn:ogc:def:crs:EPSG::1234', bare numeric strings, and OGC WKT). The 404000 / 'unspecified' / '' / None sentinels all map to None, so callers no longer have to special-case them. EpsgCode is re-exported from evo.objects.typed for backwards compatibility. The Pydantic _load_crs / _dump_crs serialisers and the CoordinateReferenceSystem alias stay in evo-objects, as they are schema-shape concerns. Bumps evo-sdk-common to 0.5.26 and raises the evo-objects floor accordingly.

## Checklist
- [x] I have read the contributing guide and the code of conduct
