### PR TITLE
Fix common package version

### DIFF
--- a/packages/evo-objects/pyproject.toml
+++ b/packages/evo-objects/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 dependencies = [
-    "evo-sdk-common[jmespath]>=0.5.28",
+    "evo-sdk-common[jmespath]>=0.5.26",
     "pydantic>=2,<3",
 ]
 


### PR DESCRIPTION
## Description

Fix common package version declared in evo-objects. 0.5.28 doesn't exist yet, and 0.5.26 is the latest.

## Checklist

- [x] I have read the contributing guide and the code of conduct
