### PR TITLE
Handle some race conditions in downloading data

### DIFF
--- a/packages/evo-sdk-common/pyproject.toml
+++ b/packages/evo-sdk-common/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evo-sdk-common"
 description = "Python package that establishes a common framework for use by client libraries that interact with Seequent Evo APIs"
-version = "0.5.26"
+version = "0.5.27"
 requires-python = ">=3.10"
 license-files = ["LICENSE.md"]
 dynamic = ["readme"]

--- a/packages/evo-sdk-common/src/evo/common/io/download.py
+++ b/packages/evo-sdk-common/src/evo/common/io/download.py
@@ -9,11 +9,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generic, TypeVar
+from weakref import WeakValueDictionary
 
 from evo import logging
 
@@ -26,6 +28,8 @@ from .http import HTTPSource
 logger = logging.getLogger("io.download")
 
 T = TypeVar("T", bound=ResourceMetadata)
+
+_cache_download_locks: WeakValueDictionary[Path, asyncio.Lock] = WeakValueDictionary()
 
 
 class Download(ABC, Generic[T]):
@@ -141,12 +145,16 @@ class Download(ABC, Generic[T]):
         :raises ChunkedIOException: if a non-recoverable exception occurred.
         :raises RetryError: if the maximum number of consecutive attempts have failed.
         """
-        location = self._get_cache_location(cache)
-        if not location.exists() or overwrite:
-            await self.download_to_path(
-                filename=location, transport=transport, max_workers=max_workers, retry=retry, fb=fb
-            )
-        else:
-            logger.debug(f"Skipping download because data already in cache (label: {self.label})")
-            fb.progress(1.0)
+        location = self._get_cache_location(cache).resolve()
+        # Serialize same-process downloads for this path. The weak-value dictionary drops the entry once no active
+        # caller or waiter holds the lock.
+        lock = _cache_download_locks.setdefault(location, asyncio.Lock())
+        async with lock:
+            if not location.exists() or overwrite:
+                await self.download_to_path(
+                    filename=location, transport=transport, max_workers=max_workers, retry=retry, fb=fb
+                )
+            else:
+                logger.debug(f"Skipping download because data already in cache (label: {self.label})")
+                fb.progress(1.0)
         return location

--- a/packages/evo-sdk-common/src/evo/common/io/http.py
+++ b/packages/evo-sdk-common/src/evo/common/io/http.py
@@ -327,7 +327,13 @@ class HTTPSource(HTTPIOBase, ISource):
                 tmp_path = Path(tmp_file.name).resolve()
 
                 logger.debug(f"Renaming {tmp_path.name} to {dst_path.name}")
-                tmp_path.replace(dst_path)
+                try:
+                    tmp_path.replace(dst_path)
+                except PermissionError:
+                    if overwrite or not dst_path.exists():
+                        raise
+                    logger.debug(f"Using file already published by another process: {dst_path}")
+                    tmp_path.unlink()
 
             except BaseException:
                 if tmp_file is not None:

--- a/packages/evo-sdk-common/tests/common/io/test_download.py
+++ b/packages/evo-sdk-common/tests/common/io/test_download.py
@@ -9,6 +9,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import asyncio
 from pathlib import Path
 from uuid import UUID
 
@@ -76,4 +77,27 @@ class TestDownload(TestWithDownloadHandler):
         self.assert_download_requests(self.url_generator.current_url)
         self.assertEqual(expected_data_file, actual_data_file)
         self.assertTrue(expected_data_file.exists())
+        self.assertEqual(TEST_DATA, expected_data_file.read_bytes())
+
+    async def test_concurrent_downloads_to_cache(self) -> None:
+        """Concurrent requests for the same cached file only download it once."""
+        download = MyDownload(
+            MyResourceMetadata(
+                environment=self.environment,
+                id=UUID(int=4322),
+                name="test_concurrent_download.csv",
+                created_at=utc_datetime(2024),
+                created_by=None,
+            ),
+            self.url_generator,
+        )
+        expected_data_file = download._get_cache_location(self.cache)
+
+        locations = await asyncio.gather(
+            download.download_to_cache(self.cache, self.transport),
+            download.download_to_cache(self.cache, self.transport),
+        )
+
+        self.assertEqual([expected_data_file, expected_data_file], locations)
+        self.assert_download_requests(self.url_generator.current_url)
         self.assertEqual(TEST_DATA, expected_data_file.read_bytes())

--- a/packages/evo-sdk-common/tests/common/io/test_http.py
+++ b/packages/evo-sdk-common/tests/common/io/test_http.py
@@ -9,6 +9,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from pathlib import Path
 from unittest import mock
 
 from evo.common.connector import APIConnector
@@ -74,6 +75,20 @@ class TestHTTPSource(TestISource, TestWithDownloadHandler):
         test_data_file = self.CACHE_DIR / "test_data_download.csv"
         self.assertFalse(test_data_file.exists())
         await HTTPSource.download_file(str(test_data_file), self.url_generator.get_new_url, self.transport)
+        self.assertTrue(test_data_file.exists())
+        self.assertEqual(TEST_DATA, test_data_file.read_bytes())
+
+    async def test_download_file_uses_concurrently_published_file(self) -> None:
+        """Test that a concurrent process publishing the destination is accepted."""
+        test_data_file = self.CACHE_DIR / "test_data_download_concurrent.csv"
+
+        def publish_from_other_process(destination: Path) -> None:
+            destination.write_bytes(TEST_DATA)
+            raise PermissionError("The destination is in use")
+
+        with mock.patch("evo.common.io.http.Path.replace", side_effect=publish_from_other_process):
+            await HTTPSource.download_file(test_data_file, self.url_generator.get_new_url, self.transport)
+
         self.assertTrue(test_data_file.exists())
         self.assertEqual(TEST_DATA, test_data_file.read_bytes())
 


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/SeequentEvo/evo-python-sdk/blob/main/CONTRIBUTING.md) before opening your first
pull request.
-->

## Description

This PR attempts to fix a couple race conditions that can happen when downloading data.

1. In `download_file` it can be the case that two different processes download the same file at the same time. They will both download different temporary files, but if one finishes downloading and renames before the other one, the second process will throw a `PermissionError`. If the file exists, the `PermissionError` is ignored and the destination path points to a valid file.
2. A lock was added to prevent concurrent coroutines in the same process from duplicating a download. This is rarer as the user isn't likely to be downloading the same exact file from two coroutines. Subsequent callers will wait and use the cached result.

## Checklist

- [x] I have read the contributing guide and the code of conduct
