### PR TITLE
Applied bug fixes and updated tests.

### DIFF
--- a/packages/evo-objects/src/evo/objects/typed/_data.py
+++ b/packages/evo-objects/src/evo/objects/typed/_data.py
@@ -49,7 +49,7 @@ class DataTable(SchemaModel):
         :param df: DataFrame containing the new values for this table.
         :param fb: Optional feedback object to report upload progress.
         """
-        self._document.update(await self._data_to_schema(df, self._context, fb=fb))
+        self._document.update(await self._data_to_schema(df, self._obj, fb=fb))
 
         # Mark the context as modified so loading data is not allowed
         self._context.mark_modified(self._data)

--- a/packages/evo-objects/src/evo/objects/typed/_model.py
+++ b/packages/evo-objects/src/evo/objects/typed/_model.py
@@ -175,7 +175,7 @@ def _set_property_value(schema_property: BaseSchemaProperty, document: dict[str,
 class SchemaBuilder:
     """Helper class to build a schema document by applying SchemaProperty values."""
 
-    def __init__(self, schema_model_cls: type[SchemaModel], context: ModelContext) -> None:
+    def __init__(self, schema_model_cls: type[SchemaModel], context: IContext) -> None:
         self.document: dict[str, Any] = {}
         self._properties = schema_model_cls._schema_properties
         self._sub_models = schema_model_cls._sub_models

--- a/packages/evo-objects/src/evo/objects/typed/pointset.py
+++ b/packages/evo-objects/src/evo/objects/typed/pointset.py
@@ -129,7 +129,7 @@ class PointSet(BaseSpatialObject):
         :param fb: Optional feedback object to report download progress.
         :return: A DataFrame with 'x', 'y', 'z' columns representing point coordinates.
         """
-        return await self.locations._table.get_dataframe(fb=fb)
+        return await self.locations._table.to_dataframe(fb=fb)
 
     async def to_dataframe(self, *keys: str, fb: IFeedback = NoFeedback) -> pd.DataFrame:
         """Get the full dataframe for the pointset, including coordinates and attributes.

--- a/packages/evo-objects/tests/typed/helpers.py
+++ b/packages/evo-objects/tests/typed/helpers.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import copy
 import uuid
+from collections.abc import Callable
 from unittest.mock import Mock
 
 import pandas as pd
@@ -136,3 +137,19 @@ class MockClient:
         assert reference.object_id is not None, "Reference must have an object ID"
         object_dict = copy.deepcopy(self.objects[str(reference.object_id)])
         return MockDownloadedObject(self, object_dict)
+
+
+def mock_data_client(mock_client: MockClient) -> Callable[[IContext], MockClient]:
+    """Build a `get_data_client` stand-in for patching.
+
+    The accessors are called so that a caller passing something that is not an `IContext` fails here, exactly as it
+    would against the real `get_data_client`.
+    """
+
+    def get_data_client(context: IContext) -> MockClient:
+        context.get_connector()
+        context.get_environment()
+        context.get_cache()
+        return mock_client
+
+    return get_data_client

--- a/packages/evo-objects/tests/typed/test_base_extensions.py
+++ b/packages/evo-objects/tests/typed/test_base_extensions.py
@@ -26,7 +26,7 @@ from evo.objects.typed import PointSet, PointSetData, Regular3DGrid, Regular3DGr
 from evo.objects.typed.base import _BaseObject
 from evo.objects.typed.types import Point3, Size3d, Size3i
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestRefreshMethodExists(TestCase):
@@ -60,8 +60,8 @@ class TestRefreshOnPointSet(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),
@@ -143,8 +143,8 @@ class TestRefreshOnRegular3DGrid(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),

--- a/packages/evo-objects/tests/typed/test_downhole_collection.py
+++ b/packages/evo-objects/tests/typed/test_downhole_collection.py
@@ -35,7 +35,7 @@ from evo.objects.typed.downhole_collection import (
 )
 from evo.objects.typed.exceptions import ObjectValidationError
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 def _make_example_data(
@@ -125,9 +125,9 @@ class TestDownholeCollection(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._utils.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._utils.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),

--- a/packages/evo-objects/tests/typed/test_downhole_intervals.py
+++ b/packages/evo-objects/tests/typed/test_downhole_intervals.py
@@ -28,7 +28,7 @@ from evo.objects.typed.attributes import AttributeDescription
 from evo.objects.typed.base import BaseObject
 from evo.objects.typed.exceptions import ObjectValidationError
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 _N = 4  # number of test intervals
 
@@ -66,8 +66,8 @@ class TestDownholeIntervals(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),

--- a/packages/evo-objects/tests/typed/test_model.py
+++ b/packages/evo-objects/tests/typed/test_model.py
@@ -26,7 +26,7 @@ from evo.objects.typed._data import DataTable, DataTableAndAttributes
 from evo.objects.typed._model import SchemaBuilder, SchemaLocation, SchemaModel
 from evo.objects.utils.table_formats import FLOAT_ARRAY_3, KnownTableFormat
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestSchemaConstants(TestWithConnector):
@@ -85,8 +85,8 @@ class TestDataTableAndAttributesBuildFromData(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
         ):
             yield mock_client
 

--- a/packages/evo-objects/tests/typed/test_pointset.py
+++ b/packages/evo-objects/tests/typed/test_pointset.py
@@ -25,7 +25,7 @@ from evo.objects.typed import BoundingBox, PointSet, PointSetData
 from evo.objects.typed.base import BaseObject
 from evo.objects.typed.exceptions import ObjectValidationError
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestPointSet(TestWithConnector):
@@ -41,8 +41,8 @@ class TestPointSet(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed._data.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed._data.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),
@@ -142,6 +142,16 @@ class TestPointSet(TestWithConnector):
 
             actual_df = await result.locations.to_dataframe()
             pd.testing.assert_frame_equal(actual_df, self.example_pointset.locations)
+
+    async def test_coordinates(self):
+        """Test that coordinates() returns only the x, y, z columns."""
+        with self._mock_geoscience_objects():
+            obj = await PointSet.create(context=self.context, data=self.example_pointset)
+
+            actual_df = await obj.coordinates()
+
+        expected_df = self.example_pointset.locations[["x", "y", "z"]]
+        pd.testing.assert_frame_equal(actual_df, expected_df)
 
     def test_bounding_box_from_data(self):
         """Test that the bounding box is computed correctly from the data."""

--- a/packages/evo-objects/tests/typed/test_regular_grid.py
+++ b/packages/evo-objects/tests/typed/test_regular_grid.py
@@ -28,7 +28,7 @@ from evo.objects.typed.attributes import DataLoaderError
 from evo.objects.typed.base import BaseObject
 from evo.objects.typed.exceptions import ObjectValidationError
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestRegularGrid(TestWithConnector):
@@ -44,7 +44,7 @@ class TestRegularGrid(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),

--- a/packages/evo-objects/tests/typed/test_regular_masked_grid.py
+++ b/packages/evo-objects/tests/typed/test_regular_masked_grid.py
@@ -26,7 +26,7 @@ from evo.objects.typed import Point3, Rotation, Size3d, Size3i
 from evo.objects.typed.exceptions import ObjectValidationError
 from evo.objects.typed.regular_masked_grid import RegularMasked3DGrid, RegularMasked3DGridData
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestRegularMaskedGrid(TestWithConnector):
@@ -42,8 +42,8 @@ class TestRegularMaskedGrid(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
-            patch("evo.objects.typed.regular_masked_grid.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
+            patch("evo.objects.typed.regular_masked_grid.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),

--- a/packages/evo-objects/tests/typed/test_tensor_grid.py
+++ b/packages/evo-objects/tests/typed/test_tensor_grid.py
@@ -26,7 +26,7 @@ from evo.objects.typed import Point3, Rotation, Size3i
 from evo.objects.typed.exceptions import ObjectValidationError
 from evo.objects.typed.tensor_grid import Tensor3DGrid, Tensor3DGridData
 
-from .helpers import MockClient
+from .helpers import MockClient, mock_data_client
 
 
 class TestTensorGrid(TestWithConnector):
@@ -42,7 +42,7 @@ class TestTensorGrid(TestWithConnector):
     def _mock_geoscience_objects(self):
         mock_client = MockClient(self.environment)
         with (
-            patch("evo.objects.typed.attributes.get_data_client", lambda _: mock_client),
+            patch("evo.objects.typed.attributes.get_data_client", mock_data_client(mock_client)),
             patch("evo.objects.typed.base.create_geoscience_object", mock_client.create_geoscience_object),
             patch("evo.objects.typed.base.replace_geoscience_object", mock_client.replace_geoscience_object),
             patch("evo.objects.DownloadedObject.from_context", mock_client.from_reference),


### PR DESCRIPTION
## Summary

Fix several typed-object data-access paths that passed the wrong object into schema construction and used an outdated pointset table method.

- `DataTable.update_dataframe()` now passes the owning Evo object to `_data_to_schema()` instead of the internal model context. This ensures the data client receives an object implementing the expected context accessors.
- `SchemaBuilder` now accepts the broader `IContext` interface, matching the contexts used by typed-object schema construction.
- `PointSet.coordinates()` now uses `to_dataframe()` on its locations table, restoring coordinate retrieval through the current table API.

## Test Coverage

Strengthened typed-object test mocks so patched `get_data_client()` calls verify that their input exposes the required context API:

- `get_connector()`
- `get_environment()`
- `get_cache()`

This makes tests fail when a model context is passed where an Evo object is required.

Added a pointset regression test confirming that `coordinates()` returns only the `x`, `y`, and `z` columns. Updated affected tests to use the stricter mock helper.

## Validation

```sh
uv run --directory packages/evo-objects pytest tests/typed -q
```

## Checklist

- [x] I have read the contributing guide and the code of conduct
