### PR TITLE
Add kriging diagnostic outputs to the task SDK client

### DIFF
--- a/code-samples/geoscience-objects/running-kriging-compute/README.md
+++ b/code-samples/geoscience-objects/running-kriging-compute/README.md
@@ -38,6 +38,7 @@ The variogram uses two nested spherical structures aligned with the dominant ori
 The notebook includes work-in-progress sections demonstrating:
 - Creating a target `BlockModel` for estimation
 - Configuring `KrigingParameters` with search neighborhoods
+- Requesting `KrigingDiagnostics` (kriging variance, slope of regression, sample counts, ...) alongside the estimate
 - Running kriging tasks with `evo.compute`
 - Running multiple scenarios in parallel for sensitivity analysis
 

--- a/code-samples/geoscience-objects/running-kriging-compute/running-kriging-compute.ipynb
+++ b/code-samples/geoscience-objects/running-kriging-compute/running-kriging-compute.ipynb
@@ -621,7 +621,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from evo.compute.tasks import SearchNeighborhood\n",
+    "from evo.compute.tasks import KrigingDiagnostics, SearchNeighborhood\n",
     "from evo.compute.tasks.geostatistics.kriging import KrigingParameters\n",
     "\n",
     "# Use the search ellipsoid we created earlier (2x variogram range)\n",
@@ -634,10 +634,60 @@
     "        max_samples=16,  # Maximum samples per estimate\n",
     "        min_samples=4,  # Minimum samples required\n",
     "    ),\n",
+    "    # Write diagnostics next to the estimate, using the recommended names\n",
+    "    diagnostics=KrigingDiagnostics(\n",
+    "        kriging_variance=True,  # -> \"KV\"\n",
+    "        slope_of_regression=True,  # -> \"SoR\"\n",
+    "        num_samples=True,  # -> \"NS\"\n",
+    "    ),\n",
     ")\n",
     "\n",
     "print(\"Kriging source: CU_pct from pointset\")\n",
     "print(f\"Search ellipsoid: major={search_ellipsoid.ranges.major}m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optional: request kriging diagnostics\n",
+    "\n",
+    "Kriging can write per-location **diagnostics** onto the target object alongside the estimate. Only the diagnostics you ask for are computed, and each one gets its own attribute — so every name must differ from the estimate's attribute name and from the other diagnostics.\n",
+    "\n",
+    "Each field of `KrigingDiagnostics` accepts:\n",
+    "\n",
+    "- `True` — create an attribute using the recommended name (these match Leapfrog's conventions, so results are familiar once imported).\n",
+    "- a string — create an attribute with that name instead.\n",
+    "- an attribute from the target object — update it if it already exists, otherwise create it.\n",
+    "\n",
+    "```python\n",
+    "from evo.compute.tasks import KrigingDiagnostics\n",
+    "\n",
+    "diagnostics = KrigingDiagnostics(\n",
+    "    kriging_variance=True,  # creates \"KV\"\n",
+    "    kriging_efficiency=\"CU_efficiency\",  # creates \"CU_efficiency\"\n",
+    "    num_samples=block_model.attributes[\"NS\"],  # updates \"NS\" if it already exists\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "| Diagnostic | Recommended name | Description |\n",
+    "| --- | --- | --- |\n",
+    "| `valid` | `valid` | Whether the location's neighbourhood satisfied the search constraints and produced an estimate. |\n",
+    "| `kriging_variance` | `KV` | Kriging variance (estimation uncertainty). |\n",
+    "| `slope_of_regression` | `SoR` | Slope of regression, a diagnostic for conditional bias. |\n",
+    "| `kriging_efficiency` | `KE` | Proportion of point or intra-block variance explained by the kriging weights. |\n",
+    "| `kriging_mean` | `KM` | GLS mean for ordinary kriging, or the supplied constant mean for simple kriging. |\n",
+    "| `num_samples` | `NS` | Number of data samples used in the estimate. |\n",
+    "| `num_drillholes` | `NDh` | Number of distinct drillholes contributing to the estimate. Requires a downhole-intervals source. |\n",
+    "| `num_duplicates` | `ND` | Number of duplicate sample locations used in the estimate. |\n",
+    "| `num_equidistant` | `NeD` | Hint of how many other samples could have replaced the last returned sample because they were the same distance away. |\n",
+    "| `sum_weights` | `Sum` | Sum of the kriging weights applied to data samples. |\n",
+    "| `sum_positive_weights` | `SumP` | Sum of the positive kriging weights. |\n",
+    "| `sum_negative_weights` | `SumN` | Sum of the negative kriging weights. |\n",
+    "| `min_distance` | `MinD` | Minimum isotropic Euclidean distance from the location to any neighbour. |\n",
+    "| `mean_distance` | `AvgD` | Mean isotropic Euclidean distance from the location to all neighbours. |\n",
+    "| `aniso_min_distance` | `MinAD` | Minimum anisotropic (ellipsoid-space) distance from the location to any neighbour. |\n",
+    "| `aniso_mean_distance` | `AvgAD` | Mean anisotropic (ellipsoid-space) distance from the location to all neighbours. |\n"
    ]
   },
   {
@@ -692,7 +742,12 @@
     "result = await run(manager, params, preview=True)\n",
     "\n",
     "print(\"Kriging complete!\")\n",
-    "print(f\"Result: {result.message}\")"
+    "print(f\"Result: {result.message}\")\n",
+    "print(f\"Estimate attribute: {result.attribute_name}\")\n",
+    "\n",
+    "# The result reports the definitive name of every diagnostic attribute that was written\n",
+    "for diagnostic, attribute in result.diagnostics.items():\n",
+    "    print(f\"  {diagnostic}: {attribute.name}\")"
    ]
   },
   {
@@ -743,12 +798,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the kriged values as a DataFrame\n",
-    "results_df = await block_model.to_dataframe(columns=[\"CU_estimate\"])\n",
+    "# Get the kriged values and their diagnostics as a DataFrame\n",
+    "diagnostic_columns = [attribute.name for attribute in result.diagnostics.values()]\n",
+    "results_df = await block_model.to_dataframe(columns=[\"CU_estimate\", *diagnostic_columns])\n",
     "\n",
     "print(f\"Estimated {len(results_df)} blocks\")\n",
     "print(\"\\nStatistics for CU_estimate:\")\n",
-    "print(results_df[\"CU_estimate\"].describe())"
+    "print(results_df[\"CU_estimate\"].describe())\n",
+    "\n",
+    "print(\"\\nDiagnostics:\")\n",
+    "print(results_df[diagnostic_columns].describe())"
    ]
   },
   {

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingMethod.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingMethod.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="Filter.html" class="nav-link">
+                                <a rel="prev" href="KrigingDiagnosticsResult.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingParameters.html
@@ -120,6 +120,15 @@
     ...             values=["LMS1", "LMS2"],
     ...         ),
     ...     ),
+    ... )
+    &gt;&gt;&gt;
+    &gt;&gt;&gt; # With diagnostics written alongside the estimate:
+    &gt;&gt;&gt; params_with_diagnostics = KrigingParameters(
+    ...     source=pointset.attributes["grade"],
+    ...     target=block_model.attributes["kriged_grade"],
+    ...     variogram=variogram,
+    ...     search=SearchNeighborhood(...),
+    ...     diagnostics=KrigingDiagnostics(kriging_variance=True, num_samples=True),
     ... )</p>
 
 
@@ -299,6 +308,28 @@
 and the kriged value is averaged across these sub-cells. When omitted,
 point kriging is performed. Only applicable when the target is a 3D grid
 or block model.</p>
+
+    </div>
+
+</div>
+
+<div class="doc doc-object doc-attribute">
+
+
+
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingParameters.diagnostics" class="doc doc-heading">
+            <span class="doc doc-object-name doc-attribute-name">diagnostics</span>
+
+
+</h3>
+<div class="doc-signature highlight"><pre><span></span><code><span class="n">diagnostics</span><span class="p">:</span> <span class="n">KrigingDiagnostics</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span><span class="kc">None</span><span class="p">,</span> <span class="n">exclude</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+</code></pre></div>
+
+    <div class="doc doc-contents ">
+
+        <p>Optional diagnostics to write onto the target object alongside the estimate.</p>
+<p>Only the diagnostics you select are computed. See :class:<code>KrigingDiagnostics</code>
+for the available outputs and the shorthands each of them accepts.</p>
 
     </div>
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResult.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResult.html
@@ -191,6 +191,32 @@
 
 
 
+<h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.diagnostics" class="doc doc-heading">
+            <span class="doc doc-object-name doc-attribute-name">diagnostics</span>
+
+
+</h3>
+<div class="doc-signature highlight"><pre><span></span><code><span class="n">diagnostics</span><span class="p">:</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="n">TaskAttribute</span><span class="p">]</span>
+</code></pre></div>
+
+    <div class="doc doc-contents ">
+
+        <p>The diagnostic attributes that were written, keyed by diagnostic name.</p>
+<p>Only the diagnostics requested through
+:attr:<code>KrigingParameters.diagnostics</code> are present.</p>
+<p>Example:
+    &gt;&gt;&gt; result = await run(manager, params, preview=True)
+    &gt;&gt;&gt; result.diagnostics["kriging_variance"].name
+    'KV'</p>
+
+    </div>
+
+</div>
+
+<div class="doc doc-object doc-attribute">
+
+
+
 <h3 id="evo.compute.tasks.geostatistics.kriging.KrigingResult.schema" class="doc doc-heading">
             <span class="doc doc-object-name doc-attribute-name">schema</span>
 

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResultModel.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingResultModel.html
@@ -142,7 +142,7 @@
 
 
 </h3>
-<div class="doc-signature highlight"><pre><span></span><code><span class="n">target</span><span class="p">:</span> <span class="n">TaskTarget</span>
+<div class="doc-signature highlight"><pre><span></span><code><span class="n">target</span><span class="p">:</span> <span class="n">KrigingTargetResult</span>
 </code></pre></div>
 
     <div class="doc doc-contents ">

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingRunner.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/KrigingRunner.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="OrdinaryKriging.html" class="nav-link">
+                                <a rel="next" href="KrigingTargetResult.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/OrdinaryKriging.html
@@ -34,12 +34,12 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="KrigingRunner.html" class="nav-link">
+                                <a rel="prev" href="KrigingTargetResult.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="SimpleKriging.html" class="nav-link">
+                                <a rel="next" href="RECOMMENDED_DIAGNOSTIC_NAMES.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/kriging/SimpleKriging.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/kriging/SimpleKriging.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="OrdinaryKriging.html" class="nav-link">
+                                <a rel="prev" href="RECOMMENDED_DIAGNOSTIC_NAMES.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-compute/typed-objects/source-target/UpdateAttribute.html
+++ b/mkdocs/site/packages/evo-compute/typed-objects/source-target/UpdateAttribute.html
@@ -39,7 +39,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a rel="next" href="../../../evo-files/index.html" class="nav-link">
+                                <a rel="next" href="attribute_spec.html" class="nav-link">
                                     Next <i class="fa fa-arrow-right"></i>
                                 </a>
                             </li>

--- a/mkdocs/site/packages/evo-files/index.html
+++ b/mkdocs/site/packages/evo-files/index.html
@@ -34,7 +34,7 @@
 
                     <ul class="nav navbar-nav ms-md-auto">
                             <li class="nav-item">
-                                <a rel="prev" href="../evo-compute/typed-objects/source-target/UpdateAttribute.html" class="nav-link">
+                                <a rel="prev" href="../evo-compute/typed-objects/source-target/attribute_spec.html" class="nav-link">
                                     <i class="fa fa-arrow-left"></i> Previous
                                 </a>
                             </li>

--- a/packages/evo-compute/docs/examples/kriging.ipynb
+++ b/packages/evo-compute/docs/examples/kriging.ipynb
@@ -265,6 +265,63 @@
    "id": "18",
    "metadata": {},
    "source": [
+    "### Request Diagnostics\n",
+    "\n",
+    "Kriging can write per-location **diagnostics** onto the target object alongside the estimate — kriging variance, slope of regression, sample counts, search distances, and so on. Only the diagnostics you ask for are computed.\n",
+    "\n",
+    "Each field of `KrigingDiagnostics` accepts `True` (create an attribute using the recommended, Leapfrog-aligned name), a string (create an attribute with that name), or an attribute from the target object (update it if it already exists). Every output writes to its own attribute, so each name must be unique within the request.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evo.compute.tasks import KrigingDiagnostics\n",
+    "\n",
+    "diagnostic_params = KrigingParameters(\n",
+    "    source=source_pointset.attributes[\"Ag_ppm Values\"],\n",
+    "    target=target_grid.attributes[\"kriged_grade_diagnostics\"],\n",
+    "    variogram=variogram,\n",
+    "    search=SearchNeighborhood(\n",
+    "        ellipsoid=search_ellipsoid,\n",
+    "        max_samples=20,\n",
+    "    ),\n",
+    "    diagnostics=KrigingDiagnostics(\n",
+    "        kriging_variance=True,  # -> \"KV\"\n",
+    "        slope_of_regression=True,  # -> \"SoR\"\n",
+    "        kriging_efficiency=True,  # -> \"KE\"\n",
+    "        num_samples=\"sample_count\",  # -> \"sample_count\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(\"Submitting kriging task with diagnostics...\")\n",
+    "result = await run(manager, diagnostic_params, preview=True)\n",
+    "\n",
+    "# The result reports the definitive name of every diagnostic attribute that was written\n",
+    "for diagnostic, attribute in result.diagnostics.items():\n",
+    "    print(f\"{diagnostic}: {attribute.name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Diagnostics are written onto the target object, so they come back with the estimate\n",
+    "df = await result.to_dataframe()\n",
+    "df[[result.attribute_name, *(attribute.name for attribute in result.diagnostics.values())]].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
     "## Example 2: Create Objects and Run Kriging\n",
     "\n",
     "This example shows how to create the input objects from scratch and then run kriging."
@@ -272,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Create the Source PointSet"
@@ -281,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Create a Variogram\n",
@@ -351,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Visualize the Variogram\n",
@@ -415,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Create the Target Grid"
@@ -462,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +575,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Run Kriging on Created Objects"
@@ -527,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/packages/evo-compute/src/evo/compute/tasks/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/__init__.py
@@ -71,6 +71,7 @@ from .geostatistics.declustering import DeclusteringResult
 # Kriging-specific result types
 from .geostatistics.kriging import (
     BlockDiscretisation,
+    KrigingDiagnostics,
     KrigingResult,
 )
 
@@ -178,6 +179,7 @@ __all__ = [
     "EllipsoidRanges",
     "Filter",
     "FilterCondition",
+    "KrigingDiagnostics",
     "KrigingResult",
     "LocationWiseResult",
     "Rotation",

--- a/packages/evo-compute/src/evo/compute/tasks/common/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/common/__init__.py
@@ -26,6 +26,7 @@ from .source_target import (
     Source,
     Target,
     UpdateAttribute,
+    attribute_spec,
 )
 
 __all__ = [
@@ -55,5 +56,6 @@ __all__ = [
     "TaskRunner",
     "TaskTarget",
     "UpdateAttribute",
+    "attribute_spec",
     "run_tasks",
 ]

--- a/packages/evo-compute/src/evo/compute/tasks/common/source_target.py
+++ b/packages/evo-compute/src/evo/compute/tasks/common/source_target.py
@@ -29,6 +29,7 @@ __all__ = [
     "Source",
     "Target",
     "UpdateAttribute",
+    "attribute_spec",
 ]
 
 # All typed attribute types that compute tasks can work with.
@@ -262,6 +263,29 @@ def _source_from_attribute(attr: Source | Attribute | BlockModelAttribute) -> So
 AnySourceAttribute: TypeAlias = Annotated[Source, BeforeValidator(_source_from_attribute)]
 
 
+def attribute_spec(attr: Any) -> Any:
+    """Convert a typed attribute object to a create or update specification.
+
+    Existing attributes become an update operation referencing the attribute;
+    pending attributes become a create operation carrying the attribute name.
+    Any other value is passed through untouched so that already-constructed
+    specifications (or dicts) validate normally.
+
+    Args:
+        attr: A typed attribute object, or an already-constructed specification.
+
+    Returns:
+        A :class:`CreateAttribute` or :class:`UpdateAttribute` for typed attributes,
+        otherwise *attr* unchanged.
+    """
+    if not isinstance(attr, AnyTypedAttribute):
+        return attr
+
+    if attr.exists:
+        return UpdateAttribute(reference=_get_attribute_expression(attr))
+    return CreateAttribute(name=attr.name)
+
+
 def _validate_target_attribute(attr: Target | AnyTypedAttribute) -> Target:
     """Convert a typed attribute object to a :class:`Target`.
 
@@ -293,12 +317,7 @@ def _validate_target_attribute(attr: Target | AnyTypedAttribute) -> Target:
     # (same pattern as source_from_attribute)
     obj_url = str(attr._obj.metadata.url)
 
-    if attr.exists:
-        attr_spec = UpdateAttribute(reference=_get_attribute_expression(attr))
-    else:
-        attr_spec = CreateAttribute(name=attr.name)
-
-    return Target(object=obj_url, attribute=attr_spec)
+    return Target(object=obj_url, attribute=attribute_spec(attr))
 
 
 AnyTargetAttribute: TypeAlias = Annotated[Target, BeforeValidator(_validate_target_attribute)]

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/__init__.py
@@ -58,6 +58,7 @@ from .knn import KNNResult
 from .kriging import (
     BlockDiscretisation,
     Filter,
+    KrigingDiagnostics,
     KrigingResult,
 )
 from .location_wise import LocationWiseResult
@@ -70,6 +71,7 @@ __all__ = [
     "Filter",
     "IDWResult",
     "KNNResult",
+    "KrigingDiagnostics",
     "KrigingResult",
     "LocationWiseResult",
 ]

--- a/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py
+++ b/packages/evo-compute/src/evo/compute/tasks/geostatistics/kriging.py
@@ -40,28 +40,46 @@ import pandas as pd
 from evo.common import IContext, IFeedback
 from evo.objects import ObjectSchema
 from evo.objects.typed import BaseObject, object_from_reference
-from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, model_serializer
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    SerializerFunctionWrapHandler,
+    ValidationInfo,
+    ValidatorFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 # Import shared components
 from ..common import (
     AnySourceAttribute,
     AnyTargetAttribute,
+    CreateAttribute,
     Filter,
     GeoscienceObjectReference,
     SearchNeighborhood,
+    UpdateAttribute,
+    attribute_spec,
 )
-from ..common.results import TaskTarget
+from ..common.results import TaskAttribute, TaskTarget
 from ..common.runner import TaskRunner
+from ..common.source_target import AnyTypedAttribute
 
 __all__ = [
     # Kriging-specific (users import from evo.compute.tasks.kriging)
+    "RECOMMENDED_DIAGNOSTIC_NAMES",
     "BlockDiscretisation",
     "Filter",
+    "KrigingDiagnostics",
+    "KrigingDiagnosticsResult",
     "KrigingMethod",
     "KrigingParameters",
     "KrigingResult",
     "KrigingResultModel",
     "KrigingRunner",
+    "KrigingTargetResult",
     "OrdinaryKriging",
     "SimpleKriging",
 ]
@@ -160,6 +178,148 @@ class BlockDiscretisation(BaseModel):
 
 
 # =============================================================================
+# Diagnostic Outputs
+# =============================================================================
+
+RECOMMENDED_DIAGNOSTIC_NAMES: dict[str, str] = {
+    "valid": "valid",
+    "kriging_variance": "KV",
+    "slope_of_regression": "SoR",
+    "kriging_efficiency": "KE",
+    "kriging_mean": "KM",
+    "num_samples": "NS",
+    "num_drillholes": "NDh",
+    "num_duplicates": "ND",
+    "num_equidistant": "NeD",
+    "sum_weights": "Sum",
+    "sum_positive_weights": "SumP",
+    "sum_negative_weights": "SumN",
+    "min_distance": "MinD",
+    "mean_distance": "AvgD",
+    "aniso_min_distance": "MinAD",
+    "aniso_mean_distance": "AvgAD",
+}
+"""Recommended attribute name for each diagnostic, matching Leapfrog's naming convention."""
+
+
+def _object_identity(reference: str) -> str:
+    """The object a reference URL points at, ignoring any version query string."""
+    return reference.split("?", 1)[0]
+
+
+class KrigingDiagnostics(BaseModel):
+    """Optional per-location diagnostics written alongside the kriging estimate.
+
+    Each field selects one diagnostic and says where to write it on the target object.
+    Only the diagnostics you set are computed; the rest are left out entirely.
+
+    Every field accepts:
+
+    - ``True`` — create an attribute using the Leapfrog-aligned recommended name from
+      :data:`RECOMMENDED_DIAGNOSTIC_NAMES` (for example ``KV`` for ``kriging_variance``).
+    - a ``str`` — create an attribute with that name.
+    - a typed attribute from the target object — update it if it already exists,
+      otherwise create it.
+    - a :class:`~evo.compute.tasks.common.CreateAttribute` or
+      :class:`~evo.compute.tasks.common.UpdateAttribute` for full control.
+
+    Every output of a kriging task writes to its own attribute, so each diagnostic name
+    must differ from the estimate's attribute name and from every other diagnostic.
+
+    Example:
+        >>> diagnostics = KrigingDiagnostics(
+        ...     kriging_variance=True,  # creates "KV"
+        ...     num_samples="sample_count",  # creates "sample_count"
+        ...     slope_of_regression=block_model.attributes["SoR"],  # updates if it exists
+        ... )
+    """
+
+    model_config = {"extra": "forbid"}
+
+    _source_objects: dict[str, str] = PrivateAttr(default_factory=dict)
+    """The object each typed attribute came from, checked against the kriging target."""
+
+    valid: CreateAttribute | UpdateAttribute | None = None
+    """Whether each target location's neighbourhood satisfied the search constraints."""
+
+    kriging_variance: CreateAttribute | UpdateAttribute | None = None
+    """The kriging variance (estimation uncertainty)."""
+
+    slope_of_regression: CreateAttribute | UpdateAttribute | None = None
+    """The slope of regression, a diagnostic for conditional bias."""
+
+    kriging_efficiency: CreateAttribute | UpdateAttribute | None = None
+    """The proportion of point or intra-block variance explained by the kriging weights."""
+
+    kriging_mean: CreateAttribute | UpdateAttribute | None = None
+    """The GLS mean for ordinary kriging, or the supplied constant mean for simple kriging."""
+
+    num_samples: CreateAttribute | UpdateAttribute | None = None
+    """The number of data samples used in the estimate."""
+
+    num_drillholes: CreateAttribute | UpdateAttribute | None = None
+    """The number of distinct drillholes contributing to the estimate.
+
+    Requires a downhole intervals source object.
+    """
+
+    num_duplicates: CreateAttribute | UpdateAttribute | None = None
+    """The number of duplicate sample locations used in the estimate."""
+
+    num_equidistant: CreateAttribute | UpdateAttribute | None = None
+    """A hint of how many other samples could have replaced the last returned sample
+    because they were the same distance from the target location. Counted after searching
+    and before clipping to the maximum number of samples."""
+
+    sum_weights: CreateAttribute | UpdateAttribute | None = None
+    """The sum of kriging weights applied to data samples."""
+
+    sum_positive_weights: CreateAttribute | UpdateAttribute | None = None
+    """The sum of positive kriging weights applied to data samples."""
+
+    sum_negative_weights: CreateAttribute | UpdateAttribute | None = None
+    """The sum of negative kriging weights applied to data samples (zero when
+    negative-weight removal is enabled)."""
+
+    min_distance: CreateAttribute | UpdateAttribute | None = None
+    """The minimum isotropic Euclidean distance from the target location to any neighbour."""
+
+    mean_distance: CreateAttribute | UpdateAttribute | None = None
+    """The mean isotropic Euclidean distance from the target location to all neighbours."""
+
+    aniso_min_distance: CreateAttribute | UpdateAttribute | None = None
+    """The minimum anisotropic (ellipsoid-space) distance from the target location to any neighbour."""
+
+    aniso_mean_distance: CreateAttribute | UpdateAttribute | None = None
+    """The mean anisotropic (ellipsoid-space) distance from the target location to all neighbours."""
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _resolve_attribute(cls, value: Any, info: ValidationInfo) -> Any:
+        """Expand the shorthands each diagnostic accepts into an attribute specification."""
+        if value is True:
+            return CreateAttribute(name=RECOMMENDED_DIAGNOSTIC_NAMES[info.field_name])
+        if value is False:
+            return None
+        if isinstance(value, str):
+            return CreateAttribute(name=value)
+        return attribute_spec(value)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _remember_source_objects(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> KrigingDiagnostics:
+        """Note where each typed attribute came from, before it is reduced to a specification."""
+        sources = {}
+        if isinstance(data, dict):
+            for name, value in data.items():
+                if isinstance(value, AnyTypedAttribute) and value._obj is not None:
+                    sources[name] = str(value._obj.metadata.url)
+        diagnostics = handler(data)
+        diagnostics._source_objects.update(sources)
+        return diagnostics
+
+
+# =============================================================================
 # Kriging Parameters
 # =============================================================================
 
@@ -199,6 +359,15 @@ class KrigingParameters(BaseModel):
         ...         ),
         ...     ),
         ... )
+        >>>
+        >>> # With diagnostics written alongside the estimate:
+        >>> params_with_diagnostics = KrigingParameters(
+        ...     source=pointset.attributes["grade"],
+        ...     target=block_model.attributes["kriged_grade"],
+        ...     variogram=variogram,
+        ...     search=SearchNeighborhood(...),
+        ...     diagnostics=KrigingDiagnostics(kriging_variance=True, num_samples=True),
+        ... )
     """
 
     model_config = {"populate_by_name": True}
@@ -233,6 +402,45 @@ class KrigingParameters(BaseModel):
     or block model.
     """
 
+    diagnostics: KrigingDiagnostics | None = Field(None, exclude=True)
+    """Optional diagnostics to write onto the target object alongside the estimate.
+
+    Only the diagnostics you select are computed. See :class:`KrigingDiagnostics`
+    for the available outputs and the shorthands each of them accepts.
+    """
+
+    @model_validator(mode="after")
+    def _validate_outputs(self) -> KrigingParameters:
+        """Check that every output writes to its own attribute on the target object."""
+        if self.diagnostics is None:
+            return self
+
+        target_object = _object_identity(self.target.object)
+        for name, source in self.diagnostics._source_objects.items():
+            if _object_identity(source) != target_object:
+                raise ValueError(
+                    f"Diagnostic {name!r} references an attribute of a different object than the kriging "
+                    f"target. Diagnostics are written onto the target object, {target_object}."
+                )
+
+        outputs: list[tuple[str, CreateAttribute | UpdateAttribute]] = [("the estimate", self.target.attribute)]
+        outputs += [
+            (f"diagnostic {name!r}", spec)
+            for name in KrigingDiagnostics.model_fields
+            if (spec := getattr(self.diagnostics, name)) is not None
+        ]
+
+        written_by: dict[tuple[str, str], str] = {}
+        for label, spec in outputs:
+            attribute = spec.name if isinstance(spec, CreateAttribute) else spec.reference
+            if (owner := written_by.get((spec.operation, attribute))) is not None:
+                raise ValueError(
+                    f"{owner} and {label} both write to the attribute {attribute!r}. "
+                    "Every kriging output needs its own attribute."
+                )
+            written_by[(spec.operation, attribute)] = label
+        return self
+
     @model_serializer(mode="wrap")
     def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
         result = handler(self)
@@ -240,6 +448,8 @@ class KrigingParameters(BaseModel):
             result["source"]["filter"] = self.source_filter.model_dump()
         if self.target_filter is not None:
             result["target"]["filter"] = self.target_filter.model_dump()
+        if self.diagnostics is not None:
+            result["target"]["diagnostics"] = self.diagnostics.model_dump(mode="json", exclude_none=True)
         return result
 
 
@@ -271,6 +481,37 @@ class _BlockModelToDataFrameProtocol(Protocol):
     ) -> pd.DataFrame: ...
 
 
+class KrigingDiagnosticsResult(BaseModel):
+    """The diagnostic attributes that were written alongside the kriging estimate.
+
+    Diagnostics that were not requested come back as ``None``.
+    """
+
+    valid: TaskAttribute | None = None
+    kriging_variance: TaskAttribute | None = None
+    slope_of_regression: TaskAttribute | None = None
+    kriging_efficiency: TaskAttribute | None = None
+    kriging_mean: TaskAttribute | None = None
+    num_samples: TaskAttribute | None = None
+    num_drillholes: TaskAttribute | None = None
+    num_duplicates: TaskAttribute | None = None
+    num_equidistant: TaskAttribute | None = None
+    sum_weights: TaskAttribute | None = None
+    sum_positive_weights: TaskAttribute | None = None
+    sum_negative_weights: TaskAttribute | None = None
+    min_distance: TaskAttribute | None = None
+    mean_distance: TaskAttribute | None = None
+    aniso_min_distance: TaskAttribute | None = None
+    aniso_mean_distance: TaskAttribute | None = None
+
+
+class KrigingTargetResult(TaskTarget):
+    """Target information from a kriging task result."""
+
+    diagnostics: KrigingDiagnosticsResult | None = None
+    """The diagnostic attributes that were written, when any were requested."""
+
+
 class KrigingResultModel(BaseModel):
     """Base class for compute task results.
 
@@ -283,7 +524,7 @@ class KrigingResultModel(BaseModel):
     message: str
     """A message describing what happened in the task."""
 
-    target: TaskTarget
+    target: KrigingTargetResult
     """Target information from the task result."""
 
 
@@ -314,6 +555,27 @@ class KrigingResult:
     def attribute_name(self) -> str:
         """The name of the attribute that was created/updated."""
         return self._target.attribute.name
+
+    @property
+    def diagnostics(self) -> dict[str, TaskAttribute]:
+        """The diagnostic attributes that were written, keyed by diagnostic name.
+
+        Only the diagnostics requested through
+        :attr:`KrigingParameters.diagnostics` are present.
+
+        Example:
+            >>> result = await run(manager, params, preview=True)
+            >>> result.diagnostics["kriging_variance"].name
+            'KV'
+        """
+        diagnostics = self._target.diagnostics
+        if diagnostics is None:
+            return {}
+        return {
+            name: attribute
+            for name in type(diagnostics).model_fields
+            if (attribute := getattr(diagnostics, name)) is not None
+        }
 
     @property
     def schema(self) -> ObjectSchema:
@@ -381,6 +643,8 @@ class KrigingResult:
             f"  Target:    {self.target_name}",
             f"  Attribute: {self.attribute_name}",
         ]
+        if diagnostics := self.diagnostics:
+            lines.append(f"  Diagnostics: {', '.join(a.name for a in diagnostics.values())}")
         return "\n".join(lines)
 
 

--- a/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
+++ b/packages/evo-compute/tests/geostatistics/test_kriging_tasks.py
@@ -42,7 +42,13 @@ from evo.compute.tasks.common import (
     Ellipsoid,
     EllipsoidRanges,
 )
-from evo.compute.tasks.geostatistics.kriging import KrigingParameters
+from evo.compute.tasks.geostatistics.kriging import (
+    RECOMMENDED_DIAGNOSTIC_NAMES,
+    KrigingDiagnostics,
+    KrigingParameters,
+    KrigingResult,
+    KrigingResultModel,
+)
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -575,6 +581,277 @@ class TestKrigingParametersWithFilter(TestCase):
 
         self.assertNotIn("filter", params_dict["target"])
         self.assertNotIn("filter", params_dict["source"])
+
+
+class TestKrigingDiagnostics(TestCase):
+    """Tests for the diagnostics selected on KrigingParameters."""
+
+    def _search(self) -> SearchNeighborhood:
+        return SearchNeighborhood(
+            ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+            max_samples=20,
+        )
+
+    def _params(self, **kwargs) -> KrigingParameters:
+        return KrigingParameters(
+            source=Source(object=POINTSET_URL, attribute="grade"),
+            target=Target.new_attribute(GRID_URL, "kriged_grade"),
+            variogram=VARIOGRAM_URL,
+            search=self._search(),
+            **kwargs,
+        )
+
+    def test_true_uses_the_recommended_name(self):
+        """``True`` selects a diagnostic using its Leapfrog-aligned recommended name."""
+        diagnostics = KrigingDiagnostics(kriging_variance=True, num_samples=True)
+
+        self.assertEqual(diagnostics.kriging_variance, CreateAttribute(name="KV"))
+        self.assertEqual(diagnostics.num_samples, CreateAttribute(name="NS"))
+
+    def test_every_diagnostic_has_a_recommended_name(self):
+        """Every field can be selected with ``True``, so the name table must be complete."""
+        fields = set(KrigingDiagnostics.model_fields)
+
+        self.assertEqual(fields, set(RECOMMENDED_DIAGNOSTIC_NAMES))
+
+        diagnostics = KrigingDiagnostics(**dict.fromkeys(fields, True))
+        for field, expected in RECOMMENDED_DIAGNOSTIC_NAMES.items():
+            self.assertEqual(getattr(diagnostics, field), CreateAttribute(name=expected), field)
+
+    def test_string_creates_an_attribute_with_that_name(self):
+        diagnostics = KrigingDiagnostics(kriging_variance="my_variance")
+
+        self.assertEqual(diagnostics.kriging_variance, CreateAttribute(name="my_variance"))
+
+    def test_false_and_none_select_nothing(self):
+        diagnostics = KrigingDiagnostics(kriging_variance=False, num_samples=None)
+
+        self.assertIsNone(diagnostics.kriging_variance)
+        self.assertIsNone(diagnostics.num_samples)
+
+    def test_existing_attribute_becomes_an_update(self):
+        attr = _create_mock_source_attribute("KV", "kv-key", GRID_URL, schema_path="cell_attributes")
+
+        diagnostics = KrigingDiagnostics(kriging_variance=attr)
+
+        self.assertEqual(diagnostics.kriging_variance, UpdateAttribute(reference="cell_attributes[?key=='kv-key']"))
+
+    def test_pending_attribute_becomes_a_create(self):
+        pending = _create_pending_attribute("KV")
+
+        diagnostics = KrigingDiagnostics(kriging_variance=pending)
+
+        self.assertEqual(diagnostics.kriging_variance, CreateAttribute(name="KV"))
+
+    def test_explicit_specifications_are_kept(self):
+        diagnostics = KrigingDiagnostics(
+            kriging_variance=CreateAttribute(name="KV"),
+            num_samples=UpdateAttribute(reference="attributes[?name=='NS']"),
+        )
+
+        self.assertEqual(diagnostics.kriging_variance, CreateAttribute(name="KV"))
+        self.assertEqual(diagnostics.num_samples, UpdateAttribute(reference="attributes[?name=='NS']"))
+
+    def test_unknown_diagnostic_is_rejected(self):
+        with self.assertRaises(ValidationError):
+            KrigingDiagnostics(variance=True)
+
+    def test_diagnostics_serialize_under_target(self):
+        """Selected diagnostics are nested under ``target.diagnostics`` on the wire."""
+        params = self._params(diagnostics=KrigingDiagnostics(kriging_variance=True, num_samples="sample_count"))
+
+        params_dict = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+        self.assertNotIn("diagnostics", params_dict)
+        self.assertEqual(
+            params_dict["target"]["diagnostics"],
+            {
+                "kriging_variance": {"operation": "create", "name": "KV"},
+                "num_samples": {"operation": "create", "name": "sample_count"},
+            },
+        )
+
+    def test_unselected_diagnostics_are_not_sent(self):
+        params = self._params(diagnostics=KrigingDiagnostics(kriging_variance=True))
+
+        diagnostics = params.model_dump(mode="json", by_alias=True, exclude_none=True)["target"]["diagnostics"]
+
+        self.assertEqual(list(diagnostics), ["kriging_variance"])
+
+    def test_diagnostics_can_be_given_as_a_dict(self):
+        params = self._params(diagnostics={"slope_of_regression": True})
+
+        diagnostics = params.model_dump(mode="json", by_alias=True, exclude_none=True)["target"]["diagnostics"]
+
+        self.assertEqual(diagnostics, {"slope_of_regression": {"operation": "create", "name": "SoR"}})
+
+    def test_diagnostics_coexist_with_a_target_filter(self):
+        params = self._params(
+            diagnostics=KrigingDiagnostics(kriging_variance=True),
+            target_filter=Filter(
+                where=FilterCondition(attribute="domain_attribute", operator="in", values=["LMS1"]),
+            ),
+        )
+
+        target = params.model_dump(mode="json", by_alias=True, exclude_none=True)["target"]
+
+        self.assertIn("diagnostics", target)
+        self.assertIn("filter", target)
+
+    def test_params_without_diagnostics_send_nothing(self):
+        params = self._params()
+
+        params_dict = params.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+        self.assertNotIn("diagnostics", params_dict["target"])
+        self.assertNotIn("diagnostics", params_dict)
+
+
+class TestKrigingDiagnosticOutputValidation(TestCase):
+    """Tests that every kriging output writes to its own attribute on the target object."""
+
+    def _params(self, target: Target | None = None, **kwargs) -> KrigingParameters:
+        return KrigingParameters(
+            source=Source(object=POINTSET_URL, attribute="grade"),
+            target=target if target is not None else Target.new_attribute(GRID_URL, "kriged_grade"),
+            variogram=VARIOGRAM_URL,
+            search=SearchNeighborhood(
+                ellipsoid=Ellipsoid(ranges=EllipsoidRanges(major=100, semi_major=100, minor=50)),
+                max_samples=20,
+            ),
+            **kwargs,
+        )
+
+    def test_distinct_outputs_are_accepted(self):
+        params = self._params(diagnostics=KrigingDiagnostics(kriging_variance=True, num_samples=True))
+
+        self.assertEqual(list(params.model_dump()["target"]["diagnostics"]), ["kriging_variance", "num_samples"])
+
+    def test_two_diagnostics_cannot_share_a_name(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._params(diagnostics=KrigingDiagnostics(kriging_variance=True, kriging_efficiency="KV"))
+
+        self.assertIn("both write to the attribute 'KV'", str(ctx.exception))
+
+    def test_a_diagnostic_cannot_take_the_name_of_the_estimate(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._params(
+                target=Target.new_attribute(GRID_URL, "KV"),
+                diagnostics=KrigingDiagnostics(kriging_variance=True),
+            )
+
+        self.assertIn("the estimate and diagnostic 'kriging_variance'", str(ctx.exception))
+
+    def test_two_diagnostics_cannot_share_an_update_reference(self):
+        reference = "cell_attributes[?name=='KV']"
+        with self.assertRaises(ValidationError) as ctx:
+            self._params(
+                diagnostics=KrigingDiagnostics(
+                    kriging_variance=UpdateAttribute(reference=reference),
+                    kriging_efficiency=UpdateAttribute(reference=reference),
+                )
+            )
+
+        self.assertIn(f"both write to the attribute {reference!r}", str(ctx.exception))
+
+    def test_a_create_and_an_update_do_not_collide(self):
+        """A name and a reference are separate namespaces, so they are not compared."""
+        params = self._params(
+            diagnostics=KrigingDiagnostics(
+                kriging_variance="KV",
+                kriging_efficiency=UpdateAttribute(reference="KV"),
+            )
+        )
+
+        self.assertEqual(params.diagnostics.kriging_variance, CreateAttribute(name="KV"))
+
+    def test_an_attribute_of_the_target_object_is_accepted(self):
+        attr = _create_mock_source_attribute("KV", "kv-key", GRID_URL, schema_path="cell_attributes")
+
+        params = self._params(diagnostics=KrigingDiagnostics(kriging_variance=attr))
+
+        self.assertEqual(
+            params.diagnostics.kriging_variance,
+            UpdateAttribute(reference="cell_attributes[?key=='kv-key']"),
+        )
+
+    def test_an_attribute_of_another_object_is_rejected(self):
+        attr = _create_mock_source_attribute("KV", "kv-key", POINTSET_URL, schema_path="locations.attributes")
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._params(diagnostics=KrigingDiagnostics(kriging_variance=attr))
+
+        self.assertIn("Diagnostic 'kriging_variance' references an attribute of a different object", str(ctx.exception))
+
+    def test_a_pending_attribute_of_another_object_is_rejected(self):
+        parent = MagicMock()
+        parent.metadata.url = ObjectReference(POINTSET_URL)
+        pending = _create_pending_attribute("KV", parent_obj=parent)
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._params(diagnostics=KrigingDiagnostics(kriging_variance=pending))
+
+        self.assertIn("references an attribute of a different object", str(ctx.exception))
+
+    def test_a_versioned_target_url_still_matches(self):
+        attr = _create_mock_source_attribute("KV", "kv-key", GRID_URL, schema_path="cell_attributes")
+
+        params = self._params(
+            target=Target.new_attribute(f"{GRID_URL}?version=17", "kriged_grade"),
+            diagnostics=KrigingDiagnostics(kriging_variance=attr),
+        )
+
+        self.assertIsNotNone(params.diagnostics.kriging_variance)
+
+    def test_an_attribute_without_a_parent_object_is_not_checked(self):
+        """A standalone block model attribute carries no parent, so it cannot be verified."""
+        attr = BlockModelAttribute(name="KV", attribute_type="Float64")
+
+        params = self._params(diagnostics=KrigingDiagnostics(kriging_variance=attr))
+
+        self.assertEqual(
+            params.diagnostics.kriging_variance,
+            UpdateAttribute(reference="attributes[?name=='KV']"),
+        )
+
+
+class TestKrigingDiagnosticsResult(TestCase):
+    """Tests for the diagnostics returned in a kriging result."""
+
+    def _result(self, diagnostics: dict | None) -> KrigingResult:
+        target = {
+            "reference": GRID_URL,
+            "name": "block model",
+            "schema_id": "/objects/regular-3d-grid/1.2.0/regular-3d-grid.schema.json",
+            "attribute": {"reference": "cell_attributes[?key=='e-key']", "name": "kriged_grade"},
+        }
+        if diagnostics is not None:
+            target["diagnostics"] = diagnostics
+        return KrigingResult(MagicMock(), KrigingResultModel(message="ok", target=target))
+
+    def test_requested_diagnostics_are_exposed(self):
+        """The service returns every key, with ``null`` for diagnostics that were not requested."""
+        result = self._result(
+            {
+                **dict.fromkeys(RECOMMENDED_DIAGNOSTIC_NAMES, None),
+                "kriging_variance": {"reference": "cell_attributes[?key=='kv-key']", "name": "KV"},
+            }
+        )
+
+        self.assertEqual(list(result.diagnostics), ["kriging_variance"])
+        self.assertEqual(result.diagnostics["kriging_variance"].name, "KV")
+        self.assertEqual(result.diagnostics["kriging_variance"].reference, "cell_attributes[?key=='kv-key']")
+
+    def test_no_diagnostics_gives_an_empty_mapping(self):
+        self.assertEqual(self._result(None).diagnostics, {})
+
+    def test_diagnostics_are_listed_in_the_summary(self):
+        result = self._result({"kriging_variance": {"reference": "ref", "name": "KV"}})
+
+        self.assertIn("Diagnostics: KV", str(result))
+
+    def test_summary_omits_diagnostics_when_there_are_none(self):
+        self.assertNotIn("Diagnostics", str(self._result(None)))
 
 
 class TestBlockDiscretisation(TestCase):

--- a/packages/evo-compute/tests/test_tasks.py
+++ b/packages/evo-compute/tests/test_tasks.py
@@ -27,6 +27,7 @@ from evo.compute.tasks.geostatistics.kriging import (
     KrigingResult,
     KrigingResultModel,
     KrigingRunner,
+    KrigingTargetResult,
     OrdinaryKriging,
     SimpleKriging,
 )
@@ -125,7 +126,7 @@ def _mock_kriging_job():
     mock_job = AsyncMock()
     mock_job.wait_for_results.return_value = KrigingResultModel(
         message="ok",
-        target=TaskTarget(
+        target=KrigingTargetResult(
             reference="ref",
             name="t",
             description=None,
@@ -190,7 +191,9 @@ class TestTaskResultSchemaType(unittest.TestCase):
 
     def _make_result(self, schema_id: str):
         attr = TaskAttribute(reference="ref", name="attr")
-        target = TaskTarget(reference="ref", name="target", description=None, schema_id=schema_id, attribute=attr)
+        target = KrigingTargetResult(
+            reference="ref", name="target", description=None, schema_id=schema_id, attribute=attr
+        )
         return KrigingResult(
             context=...,
             model=KrigingResultModel(message="ok", target=target),

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ wheels = [
 
 [[package]]
 name = "evo-blockmodels"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "packages/evo-blockmodels" }
 dependencies = [
     { name = "evo-sdk-common" },


### PR DESCRIPTION
## Description

Adds support for the kriging task's diagnostic outputs to the `evo-compute` SDK client.

The kriging task can write per-location diagnostics onto the target object alongside the estimate — kriging variance, slope of regression, sample counts, search distances, and so on. These live under `target.diagnostics` in the task schema, and were previously not reachable through the SDK.

### Parameters

`KrigingParameters` gains a `diagnostics` field taking a `KrigingDiagnostics`. It is folded into `target.diagnostics` by the existing model serializer, the same way `source_filter` and `target_filter` are already folded into `source.filter` / `target.filter` — so callers keep passing a typed attribute (or a `Target`) for `target` and do not have to hand-build the nested object.

Every diagnostic accepts:

- `True` — create an attribute using the recommended name (`RECOMMENDED_DIAGNOSTIC_NAMES`, e.g. `KV`, `SoR`, `NS`)
- a string — create an attribute with that name
- a typed attribute from the target object — update it if it exists, otherwise create it
- an explicit `CreateAttribute` / `UpdateAttribute`

```python
params = KrigingParameters(
    source=pointset.attributes["CU_pct"],
    target=block_model.attributes["CU_estimate"],
    variogram=variogram,
    search=SearchNeighborhood(ellipsoid=search_ellipsoid, max_samples=16),
    diagnostics=KrigingDiagnostics(
        kriging_variance=True,        # -> "KV"
        slope_of_regression=True,     # -> "SoR"
        num_samples="sample_count",   # -> "sample_count"
    ),
)
```

The recommended names match the conventions used elsewhere in the product so results are familiar once imported. They are the schema's suggested names rather than server-side defaults, so the SDK always sends an explicit attribute name.

### Validation

Two rules the task enforces server-side are checked before the payload is built, so mistakes surface as a `ValidationError` on `KrigingParameters` rather than a failed job:

- **Every output needs its own attribute.** Duplicate create names or update references are rejected, including a diagnostic colliding with `target.attribute`. Create names and update references are compared separately, since they are distinct namespaces.
- **Diagnostics belong to the target object.** A typed attribute is reduced to a name or reference, which is then resolved against `target.object` — so an attribute taken from a different object would silently resolve to nothing, or to the wrong attribute. The originating object is now remembered during validation and compared with the target, ignoring any `?version=` suffix. Attributes that carry no parent object cannot be checked and are left alone.

### Results

The task returns every diagnostic key, with `null` for the ones that were not requested. New `KrigingDiagnosticsResult` and `KrigingTargetResult` models parse that, and `KrigingResult.diagnostics` exposes only the diagnostics that were actually written, keyed by diagnostic name:

```python
for diagnostic, attribute in result.diagnostics.items():
    print(f"{diagnostic}: {attribute.name}")
```

They are also listed in the result summary. Because diagnostics are written onto the target object, `result.to_dataframe()` returns them alongside the estimate.

### Other changes

- `attribute_spec()` factored out of `_validate_target_attribute` in `tasks/common/source_target.py` and shared, so a diagnostic accepts the same typed attributes as a target does.
- `KrigingDiagnostics` exported from `evo.compute.tasks` and `evo.compute.tasks.geostatistics`.
- `tests/test_tasks.py` fixtures build a `KrigingTargetResult` instead of a bare `TaskTarget`, following the retyped `KrigingResultModel.target`.

### Backwards compatibility

No breaking change to the SDK's public surface — `diagnostics` is optional and defaults to `None`, so existing kriging calls produce an identical payload.

## Testing

- `uv run --package evo-compute pytest packages/evo-compute/tests` — 440 passed (27 new tests covering the accepted shorthands, the serialized payload, the parsed result, and the two validation rules).
- `ruff check` and `ruff format --check` clean across the repository.
- The generated payload and a realistic result payload were validated against the kriging task's JSON schema with `jsonschema` (Draft 2020-12) — no errors on either side.
- Notebooks were verified to parse; they need live Evo credentials to execute, so they were not run end to end.

## Documentation

- `packages/evo-compute/docs/examples/kriging.ipynb` — new "Request Diagnostics" section.
- `code-samples/geoscience-objects/running-kriging-compute/` — the walkthrough now requests diagnostics, prints the attributes that were written, and includes them in the results DataFrame; the markdown documents the shorthands and lists all 16 diagnostics with their recommended names.

The generated API reference under `mkdocs/` is left to the documentation workflow.

## Checklist

- [x] I have read the contributing guide and the code of conduct
